### PR TITLE
Simplify pypi publish workflow trigger.

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,11 +1,7 @@
 name: Publish to PyPI
 
 on:
-  workflow_run:
-    workflows: ["Run Code Checks"]
-    branches: [pypi/publish]
-    types:
-      - completed
+  push:
 
 jobs:
   publish-pypi:


### PR DESCRIPTION
PYPI action wasn't triggering.  This part of the 1.0.5 release.