### PR TITLE
Tweak pypi publishing workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -11,6 +11,7 @@ jobs:
   publish-pypi:
     if: |
         github.repository == 'opendatacube/odc-stats'
+        && github.event.workflow_run.conclusion == 'success'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,13 +1,16 @@
 name: Publish to PyPI
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Run Code Checks"]
+    branches: [develop]
+    types:
+      - completed
 
 jobs:
   publish-pypi:
     if: |
         github.repository == 'opendatacube/odc-stats'
-        && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/pypi/publish')
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Publish from develop branch after successful completion of code checks
This will only publish to pypi if version has been changed.
So no longer need to push to `pypi/publish` in order to make release, this "work around" only made sense in `odc-tools`.