### PR TITLE
Remove dependency on odc-stac

### DIFF
--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -4,7 +4,7 @@ import click
 import sys
 from ._cli_common import main, click_range2d
 from .utils import fuse_products, fuse_ds
-from odc.index import ordered_dss, dataset_count
+from odc.dscache.tools import ordered_dss, dataset_count
 from itertools import groupby
 
 

--- a/odc/stats/_gjson.py
+++ b/odc/stats/_gjson.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from datacube.model import GridSpec
 from datacube.utils.geometry import polygon_from_transform, Geometry
-from odc.index import solar_offset
+from odc.dscache.tools import solar_offset
 from .model import TileIdx_xy, TileIdx_txy
 
 
@@ -39,7 +39,7 @@ def compute_grid_info(
 ) -> Dict[TileIdx_xy, Any]:
     """
     Compute geojson feature for every cell in ``cells``.
-    Where ``cells`` is produced by ``odc.index.bin_dataset_stream``
+    Where ``cells`` is produced by ``bin_dataset_stream``
     """
     if title_width == 0:
         nmax = max([max(abs(ix), abs(iy)) for ix, iy in cells])

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -19,7 +19,7 @@ from datacube.utils.geometry import Geometry
 from datacube.utils.documents import transform_object_tree
 from datacube.utils.dates import normalise_dt
 
-from odc.index import chopped_dss, bin_dataset_stream, dataset_count, all_datasets
+from odc.dscache.tools import chopped_dss, bin_dataset_stream, dataset_count, all_datasets
 from odc.dscache.tools.tiling import parse_gridspec_with_name
 from odc.dscache.tools.profiling import ds_stream_test_func
 from ._text import split_and_check

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -2,8 +2,7 @@ import toolz
 from typing import Dict, Tuple, List, Any, Callable, Optional
 from collections import namedtuple
 from datetime import datetime
-from .model import DateTimeRange
-from odc.index import odc_uuid
+from .model import DateTimeRange, odc_uuid
 from datacube.storage import measurement_paths
 from datacube.model import Dataset, DatasetType
 from datacube.index.eo3 import prep_eo3

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,7 @@ install_requires =
     numpy
     odc-cloud[ASYNC]
     odc_algo
-    odc_dscache
-    odc_stac
+    odc_dscache>=0.2.2
     pandas
     pystac>=1.1.0
     eodatasets3>=0.22.0

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -54,9 +54,8 @@ dependencies:
 
   - pip=20
   - pip:
-      - odc-stac
       - odc-algo
-      - odc-dscache
+      - odc-dscache>=0.2.2
       - odc-cloud[ASYNC]
       - thredds-crawler
 


### PR DESCRIPTION
`odc.index.*` is being removed from `odc-stac` package, and this package does not use any STAC features.

- duplicate `odc_uuid` method here
- grab all the dataset streaming/grouping methods from `odc-dscache` instead
- remove `odc-stac` dependency from `setup.cfg`
- update `odc-dscache` dependency to be at least `>=0.2.2`

See https://github.com/opendatacube/odc-stac/issues/23