### PR TITLE
Add in UE filter for FC summaries

### DIFF
--- a/odc/stats/plugins/fc_percentiles.py
+++ b/odc/stats/plugins/fc_percentiles.py
@@ -15,23 +15,23 @@ NODATA = 255
 
 
 class StatsFCP(StatsPluginInterface):
-    
+
     NAME = "ga_fc_percentiles"
     SHORT_NAME = NAME
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
     PRODUCT_FAMILY = "fc_percentiles"
 
-    def __init__(
-        self,
-        **kwargs
-    ):
-        super().__init__(input_bands=["water", "pv", "bs", "npv"], **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(input_bands=["water", "pv", "bs", "npv", "ue"], **kwargs)
 
     @property
     def measurements(self) -> Tuple[str, ...]:
-        _measurments = [f"{b}_pc_{p}" for b, p in product(["pv", "bs", "npv"], ["10", "50", "90"])]
-        _measurments.append("qa")
-        return _measurments
+        _measurements = [
+            f"{b}_pc_{p}" for b, p in product(["pv", "bs", "npv"], ["10", "50", "90"])
+        ]
+        _measurements.append("qa")
+        _measurements.append("count_valid")
+        return _measurements
 
     def native_transform(self, xx):
         """
@@ -43,17 +43,24 @@ class StatsFCP(StatsPluginInterface):
         4. Calculate the clear wet pixels
         5. Drop the WOfS band
         """
-        
+
         water = xx.water & 0b1110_1111
-        dry = water == 0
         xx = xx.drop_vars(["water"])
-        xx = keep_good_only(xx, dry, nodata=NODATA)
+
+        unmixing_error_lt_30 = xx.ue < 30
+        xx = xx.drop_vars(["ue"])
+
+        dry = water == 0
+        dry_and_ue_lt_30 = dry & unmixing_error_lt_30
+
+        xx = keep_good_only(xx, dry_and_ue_lt_30, nodata=NODATA)
         xx["wet"] = water == 128
+
         return xx
 
     def fuser(self, xx):
         wet = xx["wet"]
-        xx = _xr_fuse(xx.drop_vars(["wet"]), partial(_fuse_mean_np, nodata=NODATA), '')
+        xx = _xr_fuse(xx.drop_vars(["wet"]), partial(_fuse_mean_np, nodata=NODATA), "")
 
         band, *bands = xx.data_vars.keys()
         all_bands_invalid = xx[band] == NODATA
@@ -62,11 +69,11 @@ class StatsFCP(StatsPluginInterface):
 
         xx["wet"] = _xr_fuse(wet, _fuse_or_np, wet.name) & all_bands_invalid
         return xx
-    
+
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         # (!all_bands_valid) & is_ever_wet => 0
         # (!all_bands_valid) & (!is_ever_wet) => 1
-        # all_bands_valid => 2  
+        # all_bands_valid => 2
 
         wet = xx["wet"]
         xx = xx.drop_vars(["wet"])
@@ -82,6 +89,8 @@ class StatsFCP(StatsPluginInterface):
         all_bands_valid = all_bands_valid.astype(np.uint8)
         is_ever_wet = is_ever_wet.astype(np.uint8)
         yy["qa"] = 1 + all_bands_valid - is_ever_wet * (1 - all_bands_valid)
+        yy["count_valid"] = all_bands_valid
+
         return yy
 
 

--- a/odc/stats/plugins/wofs.py
+++ b/odc/stats/plugins/wofs.py
@@ -19,7 +19,6 @@ import numpy as np
 import xarray as xr
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
-from odc.algo.io import load_with_native_transform
 from odc.algo import safe_div, apply_numexpr, keep_good_only, binary_dilation
 from odc.algo.io import dc_load
 from ._registry import StatsPluginInterface, register

--- a/tests/test_fc_percentiles.py
+++ b/tests/test_fc_percentiles.py
@@ -3,65 +3,88 @@ import numpy as np
 import xarray as xr
 import dask.array as da
 from odc.stats.plugins.fc_percentiles import StatsFCP
-import pytest 
+import pytest
 import pandas as pd
 
 
 @pytest.fixture
 def dataset():
-    band_1 = np.array([
-        [[255, 57], [20, 50]],
-        [[30, 40], [70, 80]], 
-        [[25, 52], [73, 98]], 
-    ]).astype(np.uint8)
+    band_1 = np.array(
+        [
+            [[255, 57], [20, 50]],
+            [[30, 40], [70, 80]],
+            [[25, 52], [73, 98]],
+        ]
+    ).astype(np.uint8)
 
-    band_2 = np.array([
-        [[0, 128], [128, 0]],
-        [[0, 0], [128, 0]], 
-        [[0, 0], [0b0110_1110, 0]], 
-    ]).astype(np.uint8)
+    band_2 = np.array(
+        [
+            [[0, 128], [128, 0]],
+            [[0, 0], [128, 0]],
+            [[0, 0], [0b0110_1110, 0]],
+        ]
+    ).astype(np.uint8)
+
+    band_3 = np.array(
+        [
+            [[0, 0], [0, 0]],
+            [[0, 5], [0, 0]],
+            [[0, 0], [0, 45]],
+        ]
+    ).astype(np.uint8)
 
     band_1 = da.from_array(band_1, chunks=(3, -1, -1))
     band_2 = da.from_array(band_2, chunks=(3, -1, 20))
+    band_3 = da.from_array(band_3, chunks=(3, -1, 20))
 
-    tuples = [(np.datetime64(f"2000-01-01T0{i}"), np.datetime64(f"2000-01-01")) for i in range(3)]
+    tuples = [
+        (np.datetime64(f"2000-01-01T0{i}"), np.datetime64("2000-01-01"))
+        for i in range(3)
+    ]
     index = pd.MultiIndex.from_tuples(tuples, names=["time", "solar_day"])
     coords = {
-        "x": np.linspace(10, 20, band_1.shape[2]), 
-        "y": np.linspace(0, 5, band_1.shape[1]), 
+        "x": np.linspace(10, 20, band_1.shape[2]),
+        "y": np.linspace(0, 5, band_1.shape[1]),
         "spec": index,
     }
-    
 
     data_vars = {
-        "band_1": xr.DataArray(band_1, dims=("spec", "y", "x"), attrs={"test_attr": 57}), 
-        "water": (("spec", "y", "x"), band_2)
+        "band_1": xr.DataArray(
+            band_1, dims=("spec", "y", "x"), attrs={"test_attr": 57}
+        ),
+        "ue": xr.DataArray(band_3, dims=("spec", "y", "x")),
+        "water": (("spec", "y", "x"), band_2),
     }
     xx = xr.Dataset(data_vars=data_vars, coords=coords)
+
     return xx
 
 
 @pytest.mark.parametrize("bits", [0b0000_0000, 0b0001_0000])
 def test_native_transform(dataset, bits):
-    
+
     xx = dataset.copy()
-    xx['water'] = da.bitwise_or(xx['water'], bits)
+    xx["water"] = da.bitwise_or(xx["water"], bits)
     xx = StatsFCP.native_transform(None, xx)
     assert xx["band_1"].attrs["test_attr"] == 57
-    
-    expected_result = np.array([
-        [[255, 255], [255, 50]],
-        [[30, 40], [255, 80]], 
-        [[25, 52], [255, 98]],
-    ])
+
+    expected_result = np.array(
+        [
+            [[255, 255], [255, 50]],
+            [[30, 40], [255, 80]],
+            [[25, 52], [255, 255]],
+        ]
+    )
     result = xx.compute()["band_1"].data
     assert (result == expected_result).all()
 
-    expected_result = np.array([
-        [[False, True], [True, False]],
-        [[False, False], [True, False]], 
-        [[False, False], [False, False]],
-    ])
+    expected_result = np.array(
+        [
+            [[False, True], [True, False]],
+            [[False, False], [True, False]],
+            [[False, False], [False, False]],
+        ]
+    )
     result = xx.compute()["wet"].data
     assert (result == expected_result).all()
 
@@ -70,13 +93,12 @@ def test_fusing(dataset):
     xx = StatsFCP.native_transform(None, dataset)
     xx = xx.groupby("solar_day").map(partial(StatsFCP.fuser, None))
     assert xx["band_1"].attrs["test_attr"] == 57
-    
+
     expected_result = np.array(
-        [[28, 46], [255, 76]],
+        [[28, 46], [255, 65]],
     )
     result = xx.compute()["band_1"].data
 
-    print(result.shape)
     assert (result == expected_result).all()
 
     expected_result = np.array(
@@ -94,21 +116,20 @@ def test_reduce(dataset):
     result = xx.compute()["band_1_pc_10"].data
     assert (result[0, :] == 255).all()
     assert (result[1, 0] == 255).all()
-    assert (result[1, 1] != 255).all()
+    assert (result[1, 1] == 255).all()
 
     expected_result = np.array(
-        [[1, 0], [0, 2]],
+        [[1, 0], [0, 1]],
     )
     result = xx.compute()["qa"].data
     assert (result == expected_result).all()
-    
+
     assert set(xx.data_vars.keys()) == set(
-        ["band_1_pc_10", "band_1_pc_50", "band_1_pc_90", "qa"]
+        ["band_1_pc_10", "band_1_pc_50", "band_1_pc_90", "qa", "count_valid"]
     )
 
     for band_name in xx.data_vars.keys():
         assert xx.data_vars[band_name].dtype == np.uint8
-        
-        if band_name != "qa":
+
+        if band_name not in ["qa", "count_valid"]:
             assert xx[band_name].attrs["test_attr"] == 57
-    


### PR DESCRIPTION
* Adds UE filter, set at `30`, so that any pixels with UE of greater than 30 are set to nodata
* Includes a `count_valid` variable in the output
* Minor cleaning and test fixes for the changes.