### PR TITLE
Change how the plugin config is overwritten and wo summary load data

### DIFF
--- a/odc/stats/_cli_run.py
+++ b/odc/stats/_cli_run.py
@@ -140,7 +140,7 @@ def run(
 
     _cfg.update(cfg_from_cli)
     if plugin_config is not None:
-        _cfg["plugin_config"] = plugin_config
+        _cfg["plugin_config"].update(plugin_config)
 
     if resampling is not None and len(resampling) > 0:
         _cfg.setdefault("plugin_config", {})["resampling"] = resampling

--- a/odc/stats/plugins/wofs.py
+++ b/odc/stats/plugins/wofs.py
@@ -20,7 +20,6 @@ import xarray as xr
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
 from odc.algo import safe_div, apply_numexpr, keep_good_only, binary_dilation
-from odc.stac import dc_load
 from ._registry import StatsPluginInterface, register
 
 
@@ -177,13 +176,12 @@ class StatsWofsFullHistory(StatsPluginInterface):
     def measurements(self) -> Tuple[str, ...]:
         return "count_wet", "count_clear", "frequency"
 
-    def input_data(self, datasets: Sequence[Dataset], geobox: GeoBox) -> xr.Dataset:
-        return dc_load(
-            datasets,
-            measurements=self.input_bands,
-            geobox=geobox,
-            chunks={},
-        )
+    def fuser(self, xx):
+        """
+            no fuse required since group by none
+            return loaded data
+        """
+        return xx
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         dtype = xx.count_clear.dtype


### PR DESCRIPTION
re: plugin config
-------
Current behaviour:
- plugin config from config yaml got totally overwritten by cli options

After change:
- only the same entry got overwritten, keep the different entries untouched and added from cli options

Reasoning:
Some configs can be pre-defined, some of them could be generated dynamically in the running environment, e.g., numerical parameters vs artefacts path and/or prefix. We wanna keep pre-defined terms in the config file as much as possible. They shouldn't be overwritten had it not been intended. Also we wanna append all the dynamic configs when it happens.

re: wo all-time summary data loading
------
data were loaded with a function from `odc.stac`
1. the function is obsoleted, `odc.stac.load` is loading specifically with `pystac.item` now
2. it shouldn't have been such, as the super class provides default data loading method
