### PR TITLE
Ensure GeoMAD band names match the band name of C3 Landsat data.

### DIFF
--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -53,12 +53,6 @@ class StatsGM(StatsPluginInterface):
                 "emad",
                 "bcmad",
                 "count",
-                "red",
-                "green",
-                "blue",
-                "nir",
-                "swir1",
-                "swir2",
             )
         )
 
@@ -181,28 +175,22 @@ class StatsGMLS(StatsGM):
             emad="edev",
             bcmad="bcdev",
             count="count",
-            red="nbart_red",
-            green="nbart_green",
-            blue="nbart_blue",
-            nir="nbart_nir",
-            swir1="nbart_swir_1",
-            swir2="nbart_swir_2",
         ),
         rgb_bands=None,
         **kwargs,
     ):
         if bands is None:
             bands = (
-                "red",
-                "green",
-                "blue",
-                "nir",
-                "swir1",
-                "swir2",
+                "nbart_red",
+                "nbart_red",
+                "nbart_blue",
+                "nbart_nir",
+                "nbart_swir_1",
+                "nbart_swir_2",
                 "nbart_contiguity",
             )
             if rgb_bands is None:
-                rgb_bands = ("red", "green", "blue")
+                rgb_bands = ("nbart_red", "nbart_red", "nbart_blue")
 
         super().__init__(
             bands=bands,

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -47,7 +47,19 @@ class StatsGM(StatsPluginInterface):
         self.cloud_filters = cloud_filters
         self._renames = aux_names
         self.aux_bands = tuple(
-            self._renames.get(k, k) for k in ("smad", "emad", "bcmad", "count")
+            self._renames.get(k, k)
+            for k in (
+                "smad",
+                "emad",
+                "bcmad",
+                "count",
+                "red",
+                "green",
+                "blue",
+                "nir",
+                "swir1",
+                "swir2",
+            )
         )
 
         self._work_chunks = work_chunks
@@ -164,7 +176,18 @@ class StatsGMLS(StatsGM):
         mask_band: str = "fmask",
         nodata_classes: Optional[Tuple[str, ...]] = ("nodata",),
         cloud_filters: Dict[str, Iterable[Tuple[str, int]]] = None,
-        aux_names=dict(smad="sdev", emad="edev", bcmad="bcdev", count="count"),
+        aux_names=dict(
+            smad="sdev",
+            emad="edev",
+            bcmad="bcdev",
+            count="count",
+            red="nbart_red",
+            green="nbart_green",
+            blue="nbart_blue",
+            nir="nbart_nir",
+            swir1="nbart_swir_1",
+            swir2="nbart_swir_2",
+        ),
         rgb_bands=None,
         **kwargs,
     ):


### PR DESCRIPTION
Currently the GeoMAD SR band names differ from Collection 3 NBART product.  The issue was reported by Robbie :

<img width="841" alt="image" src="https://user-images.githubusercontent.com/65524781/174743828-f555b160-7d1e-4e27-bcc1-8ba88df5e87f.png">

where left is C3 Landsat band names and right is the current GeoMAD. 

This fix is addressing the inconsistency  issue. 