### PR TITLE
load all configs from one single yaml

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 ignore = E731, E226, E203, W503
+max-line-length = 88

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,91 +14,93 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
 
-    - uses: actions/cache@v2
-      id: wheels_cache
-      with:
-        path: ./wheels
-        key: wheels-${{ github.sha }}
+      - uses: actions/cache@v2
+        id: wheels_cache
+        with:
+          path: ./wheels
+          key: wheels-${{ github.sha }}
 
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install --upgrade \
-         toml \
-         wheel \
-         twine \
-         packaging
-        python -m pip freeze
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade \
+           toml \
+           wheel \
+           twine \
+           packaging
+          python -m pip freeze
 
-    - name: Build Clean Packages
-      run: |
-        mkdir -p ./wheels/clean
-        python setup.py bdist_wheel --dist-dir ./wheels/clean/
-        python setup.py sdist --dist-dir ./wheels/clean/
-        find ./wheels/clean -type f
+      - name: Build Clean Packages
+        run: |
+          mkdir -p ./wheels/clean
+          python setup.py bdist_wheel --dist-dir ./wheels/clean/
+          python setup.py sdist --dist-dir ./wheels/clean/
+          find ./wheels/clean -type f
 
-    - name: Patch Package Versions
-      run: |
-        find . -name _version.py | xargs python ./scripts/patch_version.py ${GITHUB_RUN_NUMBER:-0}
+      - name: Patch Package Versions
+        run: |
+          find . -name _version.py | xargs python ./scripts/patch_version.py \
+            ${GITHUB_RUN_NUMBER:-0}
 
-    - name: Build Dev Packages
-      run: |
-        mkdir -p ./wheels/dev
-        python setup.py bdist_wheel --dist-dir ./wheels/dev/
-        python setup.py sdist --dist-dir ./wheels/dev/
-        find ./wheels/dev -type f
+      - name: Build Dev Packages
+        run: |
+          mkdir -p ./wheels/dev
+          python setup.py bdist_wheel --dist-dir ./wheels/dev/
+          python setup.py sdist --dist-dir ./wheels/dev/
+          find ./wheels/dev -type f
 
   build-test-env-base:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
-      id: conda_cache
-      with:
-        path: /tmp/test_env
-        key: ${{ runner.os }}-test-env-py38-${{ hashFiles('tests/test-env-py38.yml') }}
+      - uses: actions/cache@v2
+        id: conda_cache
+        with:
+          path: /tmp/test_env
+          key: ${{ runner.os }}-test-env-py38-\
+            ${{ hashFiles('tests/test-env-py38.yml') }}
 
-    - uses: conda-incubator/setup-miniconda@v2
-      if: steps.conda_cache.outputs.cache-hit != 'true'
-      with:
-        channels: conda-forge,defaults
-        channel-priority: true
-        activate-environment: ""
-        mamba-version: "*"
-        use-mamba: true
+      - uses: conda-incubator/setup-miniconda@v2
+        if: steps.conda_cache.outputs.cache-hit != 'true'
+        with:
+          channels: conda-forge,defaults
+          channel-priority: true
+          activate-environment: ""
+          mamba-version: "*"
+          use-mamba: true
 
-    - name: Dump Conda Environment Info
-      shell: bash -l {0}
-      if: steps.conda_cache.outputs.cache-hit != 'true'
-      run: |
-          conda info
-          conda list
-          mamba -V
-          conda config --show-sources
-          conda config --show
-          printenv | sort
+      - name: Dump Conda Environment Info
+        shell: bash -l {0}
+        if: steps.conda_cache.outputs.cache-hit != 'true'
+        run: |
+            conda info
+            conda list
+            mamba -V
+            conda config --show-sources
+            conda config --show
+            printenv | sort
 
-    - name: Build Python Environment for Testing
-      shell: bash -l {0}
-      if: steps.conda_cache.outputs.cache-hit != 'true'
-      run: |
-        mamba env create -f tests/test-env-py38.yml -p /tmp/test_env
+      - name: Build Python Environment for Testing
+        shell: bash -l {0}
+        if: steps.conda_cache.outputs.cache-hit != 'true'
+        run: |
+          mamba env create -f tests/test-env-py38.yml -p /tmp/test_env
 
-    - name: Check Python Env
-      shell: bash -l {0}
-      if: steps.conda_cache.outputs.cache-hit != 'true'
-      run: |
-        mamba env export -p tests/env
+      - name: Check Python Env
+        shell: bash -l {0}
+        if: steps.conda_cache.outputs.cache-hit != 'true'
+        run: |
+          mamba env export -p tests/env
 
 
   test-with-coverage:
@@ -108,64 +110,69 @@ jobs:
       - build-test-env-base
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Get Conda Environment from Cache
-      uses: actions/cache@v2
-      id: conda_cache
-      with:
-        path: /tmp/test_env
+      - uses: rickstaa/action-black@v1
+        with:
+          black_args: "--check odc/stats"
 
-        key: ${{ runner.os }}-test-env-py38-${{ hashFiles('tests/test-env-py38.yml') }}
+      - name: Get Conda Environment from Cache
+        uses: actions/cache@v2
+        id: conda_cache
+        with:
+          path: /tmp/test_env
 
-    - name: Update PATH
-      shell: bash
-      run: |
-        echo "/tmp/test_env/bin" >> $GITHUB_PATH
+          key: ${{ runner.os }}-test-env-py38-\
+            ${{ hashFiles('tests/test-env-py38.yml') }}
 
-    - name: Install in Edit mode
-      shell: bash
-      run: |
-        pip install -e . --no-deps
+      - name: Update PATH
+        shell: bash
+        run: |
+          echo "/tmp/test_env/bin" >> $GITHUB_PATH
 
-    - name: Start Test DB
-      shell: bash
-      run: |
-        echo "Launching test db"
-        pgdata=$(pwd)/.dbdata
-        initdb -D ${pgdata} --auth-host=md5 --encoding=UTF8
-        pg_ctl -D ${pgdata} -l "${pgdata}/pg.log" start
-        createdb datacube
-        datacube system init
+      - name: Install in Edit mode
+        shell: bash
+        run: |
+          pip install -e . --no-deps
 
-      env:
-        DATACUBE_DB_URL: postgresql:///datacube
+      - name: Start Test DB
+        shell: bash
+        run: |
+          echo "Launching test db"
+          pgdata=$(pwd)/.dbdata
+          initdb -D ${pgdata} --auth-host=md5 --encoding=UTF8
+          pg_ctl -D ${pgdata} -l "${pgdata}/pg.log" start
+          createdb datacube
+          datacube system init
 
-    - name: Run Tests
-      shell: bash
-      run: |
-        datacube system check
+        env:
+          DATACUBE_DB_URL: postgresql:///datacube
 
-        echo "Running Tests"
-        pytest --cov=. \
-        --cov-report=html \
-        --cov-report=xml:coverage.xml \
-        --timeout=30 \
-        tests
+      - name: Run Tests
+        shell: bash
+        run: |
+          datacube system check
 
-      env:
-        AWS_DEFAULT_REGION: us-west-2
-        DASK_TEMPORARY_DIRECTORY: /tmp/dask
-        DATACUBE_DB_URL: postgresql:///datacube
+          echo "Running Tests"
+          pytest --cov=. \
+          --cov-report=html \
+          --cov-report=xml:coverage.xml \
+          --timeout=30 \
+          tests
 
-    - name: Upload Coverage
-      if: |
-        github.repository == 'opendatacube/odc-stats'
+        env:
+          AWS_DEFAULT_REGION: us-west-2
+          DASK_TEMPORARY_DIRECTORY: /tmp/dask
+          DATACUBE_DB_URL: postgresql:///datacube
 
-      uses: codecov/codecov-action@v1
-      with:
-        fail_ci_if_error: false
-        verbose: false
+      - name: Upload Coverage
+        if: |
+          github.repository == 'opendatacube/odc-stats'
+
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: false
+          verbose: false
 
 
   test-wheels:
@@ -176,61 +183,61 @@ jobs:
       - build-wheels
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Get Wheels from Cache
-      uses: actions/cache@v2
-      id: wheels_cache
-      with:
-        path: ./wheels
-        key: wheels-${{ github.sha }}
+      - name: Get Wheels from Cache
+        uses: actions/cache@v2
+        id: wheels_cache
+        with:
+          path: ./wheels
+          key: wheels-${{ github.sha }}
 
-    - name: Get Conda Environment from Cache
-      uses: actions/cache@v2
-      id: conda_cache
-      with:
-        path: /tmp/test_env
-        key: ${{ runner.os }}-test-env-py38-${{ hashFiles('tests/test-env-py38.yml') }}
+      - name: Get Conda Environment from Cache
+        uses: actions/cache@v2
+        id: conda_cache
+        with:
+          path: /tmp/test_env
+          key: ${{ runner.os }}-test-env-py38-\
+            ${{ hashFiles('tests/test-env-py38.yml') }}
 
-    - name: Update PATH
-      shell: bash
-      run: |
-        echo "/tmp/test_env/bin" >> $GITHUB_PATH
+      - name: Update PATH
+        shell: bash
+        run: |
+          echo "/tmp/test_env/bin" >> $GITHUB_PATH
 
-    - name: Install wheels for testing
-      shell: bash
-      run: |
-        which python
-        which createdb
-        which datacube
+      - name: Install wheels for testing
+        shell: bash
+        run: |
+          which python
+          which createdb
+          which datacube
 
-        ls -lh wheels/clean
-        python -m pip install --no-deps wheels/clean/*whl
-        python -m pip check || true
+          ls -lh wheels/clean
+          python -m pip install --no-deps wheels/clean/*whl
+          python -m pip check || true
 
-    - name: Start Test DB
-      shell: bash
-      run: |
-        echo "Launching test db"
-        pgdata=$(pwd)/.dbdata
-        initdb -D ${pgdata} --auth-host=md5 --encoding=UTF8
-        pg_ctl -D ${pgdata} -l "${pgdata}/pg.log" start
-        createdb datacube
-        datacube system init
+      - name: Start Test DB
+        shell: bash
+        run: |
+          echo "Launching test db"
+          pgdata=$(pwd)/.dbdata
+          initdb -D ${pgdata} --auth-host=md5 --encoding=UTF8
+          pg_ctl -D ${pgdata} -l "${pgdata}/pg.log" start
+          createdb datacube
+          datacube system init
 
-      env:
-        DATACUBE_DB_URL: postgresql:///datacube
+        env:
+          DATACUBE_DB_URL: postgresql:///datacube
 
-    - name: Run Tests
-      shell: bash
-      run: |
-        datacube system check
+      - name: Run Tests
+        shell: bash
+        run: |
+          datacube system check
 
-        echo "Running Tests"
-        pytest --timeout=30 tests
+          echo "Running Tests"
+          pytest --timeout=30 tests
 
-      env:
-        AWS_DEFAULT_REGION: us-west-2
-        DASK_TEMPORARY_DIRECTORY: /tmp/dask
-        DATACUBE_DB_URL: postgresql:///datacube
-
+        env:
+          AWS_DEFAULT_REGION: us-west-2
+          DASK_TEMPORARY_DIRECTORY: /tmp/dask
+          DATACUBE_DB_URL: postgresql:///datacube

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+    - repo: https://github.com/adrienverge/yamllint.git
+      rev: v1.25.0
+      hooks:
+        - id: yamllint
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.2.0
+      hooks:
+        - id: end-of-file-fixer
+        - id: check-docstring-first
+        - id: check-json
+        - id: check-yaml
+        - id: debug-statements
+        - id: name-tests-test
+          args: ['--django']
+        - id: requirements-txt-fixer
+        - id: check-added-large-files
+        - id: check-merge-conflict
+    - repo: https://github.com/pre-commit/mirrors-pylint
+      rev: 'v2.6.0'  # Use the sha / tag you want to point at
+      hooks:
+      - id: pylint
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: '3.8.4'
+      hooks:
+        - id: flake8
+    - repo: https://github.com/psf/black
+      rev: 20.8b1
+      hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,30 @@
 repos:
-    - repo: https://github.com/adrienverge/yamllint.git
-      rev: v1.25.0
-      hooks:
-        - id: yamllint
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v3.2.0
-      hooks:
-        - id: end-of-file-fixer
-        - id: check-docstring-first
-        - id: check-json
-        - id: check-yaml
-        - id: debug-statements
-        - id: name-tests-test
-          args: ['--django']
-        - id: requirements-txt-fixer
-        - id: check-added-large-files
-        - id: check-merge-conflict
-    - repo: https://github.com/pre-commit/mirrors-pylint
-      rev: 'v2.6.0'  # Use the sha / tag you want to point at
-      hooks:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.25.0
+    hooks:
+      - id: yamllint
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: check-docstring-first
+      - id: check-json
+      - id: check-yaml
+      - id: debug-statements
+      - id: name-tests-test
+        args: ['--django']
+      - id: requirements-txt-fixer
+      - id: check-added-large-files
+      - id: check-merge-conflict
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: 'v2.6.0'  # Use the sha / tag you want to point at
+    hooks:
       - id: pylint
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: '3.8.4'
-      hooks:
-        - id: flake8
-    - repo: https://github.com/psf/black
-      rev: 20.8b1
-      hooks:
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: '3.8.4'
+    hooks:
+      - id: flake8
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
       - id: black

--- a/odc/stats/_cli_common.py
+++ b/odc/stats/_cli_common.py
@@ -77,12 +77,14 @@ def click_resolution(*args, **kw):
     """
     @click_resolution("--custom-flag-for-resolution", help="Whatever help")
     """
+
     def _parse(ctx, param, value):
         if value is not None:
             try:
                 return parse_resolution(value)
             except ValueError as e:
                 raise click.ClickException(str(e)) from None
+
     if len(args) == 0:
         args = ["--resolution"]
     return click.option(*args, callback=_parse, **kw)
@@ -92,9 +94,11 @@ def click_yaml_cfg(*args, **kw):
     """
     @click_yaml_cfg("--custom-flag", help="Whatever help")
     """
+
     def _parse(ctx, param, value):
         if value is not None:
             from urllib.parse import urlparse
+
             r = urlparse(value)
             if all([r.scheme, r.netloc]):
                 try:
@@ -103,10 +107,12 @@ def click_yaml_cfg(*args, **kw):
                     raise click.ClickException(str(e)) from None
             else:
                 from odc.io.text import parse_yaml_file_or_inline
+
                 try:
                     return parse_yaml_file_or_inline(value)
                 except Exception as e:
                     raise click.ClickException(str(e)) from None
+
     return click.option(*args, callback=_parse, **kw)
 
 

--- a/odc/stats/_cli_locate_grids.py
+++ b/odc/stats/_cli_locate_grids.py
@@ -8,6 +8,7 @@ from io import StringIO
 from osgeo import gdal, ogr, osr
 from ._cli_common import main
 
+
 def locate_grids(grid_shape, extent_shape, attr_filter):
     ds_grid = ogr.Open(grid_shape)
     lyr_grid = ds_grid.GetLayer(0)
@@ -28,13 +29,19 @@ def locate_grids(grid_shape, extent_shape, attr_filter):
         grid_geom.Transform(transform)
         lyr_extent.SetSpatialFilter(grid_geom)
         if lyr_extent.GetFeatureCount() > 0:
-            extent_grids += [re.findall(r'\d+', grid['region_code'])]
+            extent_grids += [re.findall(r"\d+", grid["region_code"])]
         lyr_extent.SetSpatialFilter(None)
         lyr_extent.ResetReading()
     return extent_grids
 
+
 @main.command("locate-grids")
-@click.option("--attr-filter", type=str, default=None, help="Filter the input shape by attributes, e.g., FEAT_CODE != 'sea'")
+@click.option(
+    "--attr-filter",
+    type=str,
+    default=None,
+    help="Filter the input shape by attributes, e.g., FEAT_CODE != 'sea'",
+)
 @click.argument("grid-shape", type=str)
 @click.argument("extent-shape", type=str)
 @click.argument("csv-path", type=str, required=False)
@@ -42,14 +49,14 @@ def locate_grids(grid_shape, extent_shape, attr_filter):
 def cli(attr_filter, grid_shape, extent_shape, csv_path, verbose):
     """
     Generate a list of grids overlapping with the input shape extent
-    
+
     GRID_SHAPE is the geojson or ESRI shape file of the grids.
-    
+
     EXTENT_SHAPE is the ESRI shape file where the extent covers the grids.
-    
+
     CSV_PATH is the path where the csv of the grids list will be saved, default is None.
     By default, the file will be saved in the system temporary folder.
-    
+
     """
 
     print("It takes time, not frozen...")
@@ -58,13 +65,14 @@ def cli(attr_filter, grid_shape, extent_shape, csv_path, verbose):
     csv_buffer = StringIO()
     pd.DataFrame(extent_grids).to_csv(csv_buffer, index=None, header=None)
     csv_buffer.seek(0)
-    
+
     if csv_path is None:
         tmp_path = tempfile.gettempdir()
         csv_path = path.join(tmp_path, "extent_grids.csv")
-    with open(csv_path, 'w') as f:
+    with open(csv_path, "w") as f:
         f.write(csv_buffer.read())
     print("Results saved to", csv_path)
+
 
 if __name__ == "__main__":
     cli()

--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -107,7 +107,7 @@ def save_tasks(
       - output product config
 
     """
-    setup_logging(0)
+    setup_logging()
 
     import logging
     from datacube import Datacube
@@ -122,10 +122,8 @@ def save_tasks(
     if config is None:
         config = {}
 
-    _log.debug(f"read in config : {config}")
-    _cfg = {k: config.get(k) for k in CONFIG_ITEMS}
+    _cfg = {k: config.get(k) for k in CONFIG_ITEMS if config.get(k) is not None}
 
-    _log.debug(f"read in config : {_cfg}")
     cfg_from_cli = {
         k: v
         for k, v in dict(
@@ -141,6 +139,7 @@ def save_tasks(
 
     _log.info(f"Config overrides: {cfg_from_cli}")
     _cfg.update(cfg_from_cli)
+    _log.info(f"Using config: {_cfg}")
 
     gqa = _cfg.pop("gqa", None)
     products = _cfg.pop("products", None)

--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -2,7 +2,17 @@ import json
 
 import click
 import sys
-from ._cli_common import main, click_range2d
+from ._cli_common import main, click_range2d, click_yaml_cfg, setup_logging
+
+CONFIG_ITEMS = [
+    "grid",
+    "frequency",
+    "complevel",
+    "overwrite",
+    "gqa",
+    "products",
+    "dataset_filter",
+]
 
 
 @main.command("save-tasks")
@@ -13,10 +23,6 @@ from ._cli_common import main, click_range2d
         "Grid name or spec: au-{10|20|30|60},africa-{10|20|30|60}, albers-au-25 (legacy one)"
         "'crs;pixel_resolution;shape_in_pixels'"
     ),
-    prompt="""Enter GridSpec
- one of au-{10|20|30|60}, africa-{10|20|30|60}, albers_au_25 (legacy one)
- or custom like 'epsg:3857;30;5000' (30m pixels 5,000 per side in epsg:3857)
- >""",
     default=None,
 )
 @click.option(
@@ -69,11 +75,13 @@ from ._cli_common import main, click_range2d
     "--dataset-filter",
     type=str,
     default=None,
-    help='Filter to apply on datasets - {"collection_category": "T1"}'
+    help='Filter to apply on datasets - {"collection_category": "T1"}',
 )
-@click.argument("products", type=str, nargs=1)
+@click_yaml_cfg("--config", help="Save tasks Config")
+@click.option("--products", type=str, default="")
 @click.argument("output", type=str, nargs=1, default="")
 def save_tasks(
+    config,
     grid,
     year,
     temporal_range,
@@ -99,17 +107,70 @@ def save_tasks(
       - output product config
 
     """
+    setup_logging(0)
+
+    import logging
     from datacube import Datacube
     from .tasks import SaveTasks
     from .model import DateTimeRange
 
-    filter = {}
-    if dataset_filter:
-        filter = json.loads(dataset_filter)
-
+    _log = logging.getLogger(__name__)
     if temporal_range is not None and year is not None:
         print("Can only supply one of --year or --temporal_range", file=sys.stderr)
         sys.exit(1)
+
+    if config is None:
+        config = {}
+
+    _log.debug(f"read in config : {config}")
+    _cfg = {k: config.get(k) for k in CONFIG_ITEMS}
+
+    _log.debug(f"read in config : {_cfg}")
+    cfg_from_cli = {
+        k: v
+        for k, v in dict(
+            grid=grid,
+            frequency=frequency,
+            gqa=gqa,
+            products=products,
+            complevel=complevel,
+            dataset_filter=dataset_filter,
+        ).items()
+        if v is not None and v != ""
+    }
+
+    _log.info(f"Config overrides: {cfg_from_cli}")
+    _cfg.update(cfg_from_cli)
+
+    gqa = _cfg.pop("gqa", None)
+    products = _cfg.pop("products", None)
+    dataset_filter = _cfg.pop("dataset_filter", None)
+
+    if products is None:
+        print("Input products has to be specified", file=sys.stderr)
+        sys.exit(1)
+
+    if _cfg.get("grid") is None:
+        print(
+            "grid must  be  one of au-{10|20|30|60}, africa-{10|20|30|60}, albers_au_25 (legacy one) \
+               or custom like 'epsg:3857;30;5000' (30m pixels 5,000 per side in epsg:3857) "
+        )
+        sys.exit(1)
+
+    if _cfg.get("frequency") is not None:
+        if _cfg.get("frequency") not in (
+            "annual",
+            "annual-fy",
+            "semiannual",
+            "seasonal",
+            "nov-mar",
+            "apr-oct",
+            "all",
+        ):
+            print(
+                f"Frequency must be one of annual|annual-fy|semiannual|seasonal|nov-mar|apr-oct|all and not '{frequency}'"
+            )
+            sys.exit(1)
 
     if temporal_range is not None:
         try:
@@ -121,11 +182,6 @@ def save_tasks(
     if year is not None:
         temporal_range = DateTimeRange.year(year)
 
-    if frequency is not None:
-        if frequency not in ("annual", "annual-fy", "semiannual", "seasonal", "nov-mar", "apr-oct", "all"):
-            print(f"Frequency must be one of annual|annual-fy|semiannual|seasonal|nov-mar|apr-oct|all and not '{frequency}'")
-            sys.exit(1)
-
     if output == "":
         if temporal_range is not None:
             output = f"{products}_{temporal_range.short}.db"
@@ -133,9 +189,7 @@ def save_tasks(
             output = f"{products}_all.db"
 
     try:
-        tasks = SaveTasks(
-            output, grid, frequency=frequency, overwrite=overwrite, complevel=complevel
-        )
+        tasks = SaveTasks(output, **_cfg)
     except ValueError as e:
         print(str(e))
         sys.exit(1)
@@ -158,6 +212,10 @@ def save_tasks(
         predicate = gqa_predicate
     if usgs_collection_category is not None:
         predicate = collection_category_predicate
+
+    filter = {}
+    if dataset_filter:
+        filter = json.loads(dataset_filter)
 
     dc = Datacube(env=env)
     try:

--- a/odc/stats/_text.py
+++ b/odc/stats/_text.py
@@ -6,6 +6,7 @@ PathLike = Union[str, Path]
 
 # Copied from odc.io.text
 
+
 def read_int(path: PathLike, default=None, base=10) -> Optional[int]:
     """
     Read single integer from a text file.
@@ -20,7 +21,7 @@ def read_int(path: PathLike, default=None, base=10) -> Optional[int]:
 
 
 def split_and_check(
-        s: str, separator: str, n: Union[int, Tuple[int, ...]]
+    s: str, separator: str, n: Union[int, Tuple[int, ...]]
 ) -> Tuple[str, ...]:
     """Turn string into tuple, checking that there are exactly as many parts as expected.
     :param s: String to parse
@@ -83,10 +84,11 @@ def parse_yaml_file_or_inline(s: str) -> Dict[str, Any]:
 
 def load_yaml_remote(yaml_url: str) -> Dict[str, Any]:
     """
-       Open a yaml file remotely and return the parsed yaml document 
+    Open a yaml file remotely and return the parsed yaml document
     """
     import fsspec
     import yaml
+
     try:
         with fsspec.open(yaml_url, mode="r") as f:
             return next(yaml.safe_load_all(f))
@@ -98,8 +100,12 @@ def load_yaml_remote(yaml_url: str) -> Dict[str, Any]:
 def parse_range2d_int(s: str) -> Tuple[Tuple[int, int], Tuple[int, int]]:
     """Parse string like "0:3,4:5" -> ((0,3), (4,5))"""
     from ._text import split_and_check
+
     try:
-        return tuple(tuple(int(x) for x in split_and_check(p, ":", 2)) for p in split_and_check(s, ",", 2))
+        return tuple(
+            tuple(int(x) for x in split_and_check(p, ":", 2))
+            for p in split_and_check(s, ",", 2)
+        )
     except ValueError:
         raise ValueError(
             'Expect <int>:<int>,<int>:<int> syntax, got "{}"'.format(s)

--- a/odc/stats/plugins/__init__.py
+++ b/odc/stats/plugins/__init__.py
@@ -1,6 +1,2 @@
 from ._base import StatsPluginInterface
-from ._registry import (
-    resolve,
-    import_all,
-    register
-)
+from ._registry import resolve, import_all, register

--- a/odc/stats/plugins/_base.py
+++ b/odc/stats/plugins/_base.py
@@ -15,15 +15,16 @@ class StatsPluginInterface(ABC):
     VERSION = "0.0.0"
     PRODUCT_FAMILY = "statistics"
 
-    def __init__(self,
-                 resampling: str = "bilinear",
-                 input_bands: Sequence[str] = [],
-                 chunks: Mapping[str, int] = {"y": -1, "x": -1},
-                 basis: Optional[str] = None,
-                 group_by: str = "solar_day",
-                 rgb_bands: Optional[Sequence[str]] = None,
-                 rgb_clamp: Tuple[float, float] = (1.0, 3_000.0)
-                ):
+    def __init__(
+        self,
+        resampling: str = "bilinear",
+        input_bands: Sequence[str] = [],
+        chunks: Mapping[str, int] = {"y": -1, "x": -1},
+        basis: Optional[str] = None,
+        group_by: str = "solar_day",
+        rgb_bands: Optional[Sequence[str]] = None,
+        rgb_clamp: Tuple[float, float] = (1.0, 3_000.0),
+    ):
         self.resampling = resampling
         self.input_bands = input_bands
         self.chunks = chunks

--- a/odc/stats/plugins/_registry.py
+++ b/odc/stats/plugins/_registry.py
@@ -20,7 +20,9 @@ def resolve(name: str) -> PluginFactory:
         maker = pydoc.locate(name)
         if maker is not None:
             if not issubclass(maker, (StatsPluginInterface,)):
-                raise ValueError(f"Custom StatsPlugin '{name}' is not derived from StatsPluginInterface")
+                raise ValueError(
+                    f"Custom StatsPlugin '{name}' is not derived from StatsPluginInterface"
+                )
             return partial(_new, maker)
 
     if maker is None:
@@ -52,4 +54,3 @@ def import_all():
             importlib.import_module(mod)
         except ModuleNotFoundError:
             pass
-

--- a/odc/stats/plugins/mangroves.py
+++ b/odc/stats/plugins/mangroves.py
@@ -32,24 +32,24 @@ class Mangroves(StatsPluginInterface):
         tcw_threshold=-1850,
         **kwargs,
     ):
-        self.mangroves_extent = kwargs.pop('mangroves_extent', None)
+        self.mangroves_extent = kwargs.pop("mangroves_extent", None)
         self.pv_thresholds = pv_thresholds
         self.tcw_threshold = tcw_threshold
         super().__init__(input_bands=["pv_pc_10", "qa", "wet_pc_10"], **kwargs)
 
     @property
     def measurements(self) -> Tuple[str, ...]:
-        _measurements = [
-            "canopy_cover_class"
-        ]
+        _measurements = ["canopy_cover_class"]
         return _measurements
-    
-    def rasterize_mangroves_extent(self, shape_file, array_shape, orig_coords, resolution=(30, -30)):
+
+    def rasterize_mangroves_extent(
+        self, shape_file, array_shape, orig_coords, resolution=(30, -30)
+    ):
         source_ds = ogr.Open(shape_file)
         source_layer = source_ds.GetLayer()
 
         yt, xt = array_shape[1:]
-        xres, yres = resolution 
+        xres, yres = resolution
         no_data = 0
         xcoord, ycoord = orig_coords
 
@@ -64,33 +64,38 @@ class Mangroves(StatsPluginInterface):
         band.SetNoDataValue(no_data)
 
         gdal.RasterizeLayer(target_ds, [1], source_layer, burn_values=[1])
-        return dask.array.from_array(band.ReadAsArray().reshape(array_shape), name=False)
+        return dask.array.from_array(
+            band.ReadAsArray().reshape(array_shape), name=False
+        )
 
     def fuser(self, xx):
         """
-            no fuse required for mangroves since group by none
-            return loaded data
+        no fuse required for mangroves since group by none
+        return loaded data
         """
         return xx
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         """
-            mangroves computation here
-            it is not a 'reduce' though
+        mangroves computation here
+        it is not a 'reduce' though
         """
         if self.mangroves_extent:
             if not os.path.exists(self.mangroves_extent):
                 raise FileNotFoundError(f"{self.mangroves_extent} not found")
-            extent_mask = self.rasterize_mangroves_extent(self.mangroves_extent, xx.pv_pc_10.shape,
-                                                     (xx.coords["x"].min(), xx.coords["y"].max()))
+            extent_mask = self.rasterize_mangroves_extent(
+                self.mangroves_extent,
+                xx.pv_pc_10.shape,
+                (xx.coords["x"].min(), xx.coords["y"].max()),
+            )
         else:
             extent_mask = dask.array.ones(xx.pv_pc_10.shape)
-        good_data = (extent_mask == 1)
-        good_data &= (xx.wet_pc_10 > self.tcw_threshold)
+        good_data = extent_mask == 1
+        good_data &= xx.wet_pc_10 > self.tcw_threshold
         good_data &= (xx.pv_pc_10 > self.pv_thresholds[0]) & (xx.qa == 2) | (xx.qa == 1)
-       
-        notsure_mask = (xx.qa == 1)
-    
+
+        notsure_mask = xx.qa == 1
+
         cover_type = xx.pv_pc_10.copy(True)
         cover_type.data = dask.array.zeros_like(cover_type.data)
         for s_t in self.pv_thresholds:
@@ -98,13 +103,13 @@ class Mangroves(StatsPluginInterface):
 
         cover_type = erase_bad(cover_type, notsure_mask, nodata=0)
         cover_type = keep_good_only(cover_type, good_data, nodata=NODATA)
-        cover_type.attrs['nodata'] = NODATA
+        cover_type.attrs["nodata"] = NODATA
 
         cover_type = cover_type.to_dataset(name="canopy_cover_class")
         # don't want the dimension spec from input but keep the info in case
         if "spec" in cover_type.dims:
             cover_type = cover_type.squeeze(dim=["spec"])
-        return cover_type 
+        return cover_type
 
 
 register("mangroves", Mangroves)

--- a/odc/stats/plugins/pq.py
+++ b/odc/stats/plugins/pq.py
@@ -19,15 +19,15 @@ cloud_classes = (
 # filters - dict of band name and list of iterable tuples of morphological operations
 #           in the order you want them to perform
 default_filters = {
-  "clear_2_5": [("opening", 2), ("dilation", 5)],
-  "clear_0_5": [("opening", 0), ("dilation", 5)]
+    "clear_2_5": [("opening", 2), ("dilation", 5)],
+    "clear_0_5": [("opening", 0), ("dilation", 5)],
 }
 
 
 class StatsPQ(StatsPluginInterface):
     NAME = "pc_s2_annual"
     SHORT_NAME = NAME
-    VERSION = '0.0.1'
+    VERSION = "0.0.1"
     PRODUCT_FAMILY = "pixel_quality_statistics"
 
     def __init__(
@@ -43,11 +43,7 @@ class StatsPQ(StatsPluginInterface):
 
     @property
     def measurements(self) -> Tuple[str, ...]:
-        measurements = [
-            "total",
-            "clear",
-            *list(self.filters)
-        ]
+        measurements = ["total", "clear", *list(self.filters)]
 
         return tuple(measurements)
 
@@ -68,7 +64,9 @@ class StatsPQ(StatsPluginInterface):
         if is_native:
             for band, mask_filters in self.filters.items():
                 erased_filter_band_name = band.replace("clear", "erased")
-                xx[erased_filter_band_name] = mask_cleanup(xx["erased"], mask_filters=mask_filters)
+                xx[erased_filter_band_name] = mask_cleanup(
+                    xx["erased"], mask_filters=mask_filters
+                )
 
         return xx
 

--- a/odc/stats/plugins/wofs.py
+++ b/odc/stats/plugins/wofs.py
@@ -45,11 +45,7 @@ class StatsWofs(StatsPluginInterface):
     # these get padded out if dilation was requested
     BAD_BITS_MASK = 0b0110_1000  # Cloud/Shadow + Terrain Shadow
 
-    def __init__(
-        self,
-        dilation: int = 0,
-        **kwargs
-    ):
+    def __init__(self, dilation: int = 0, **kwargs):
         super().__init__(input_bands=["water"], **kwargs)
         self._dilation = dilation  # number of pixels to pad around BAD pixels
 
@@ -170,7 +166,7 @@ class StatsWofsFullHistory(StatsPluginInterface):
     PRODUCT_FAMILY = "wo_summary"
 
     def __init__(self, **kwargs):
-        super().__init__(input_bands=['count_wet', 'count_clear'])
+        super().__init__(input_bands=["count_wet", "count_clear"])
 
     @property
     def measurements(self) -> Tuple[str, ...]:
@@ -178,8 +174,8 @@ class StatsWofsFullHistory(StatsPluginInterface):
 
     def fuser(self, xx):
         """
-            no fuse required since group by none
-            return loaded data
+        no fuse required since group by none
+        return loaded data
         """
         return xx
 

--- a/odc/stats/proc.py
+++ b/odc/stats/proc.py
@@ -29,11 +29,12 @@ Future = Any
 
 class TaskRunner:
     def __init__(
-        self, cfg: TaskRunnerConfig, resolution: Optional[Tuple[float, float]] = None, from_sqs: Optional[str] = ""
+        self,
+        cfg: TaskRunnerConfig,
+        resolution: Optional[Tuple[float, float]] = None,
+        from_sqs: Optional[str] = "",
     ):
-        """
-
-        """
+        """ """
         _log = logging.getLogger(__name__)
         self._cfg = cfg
         self._log = _log
@@ -44,7 +45,9 @@ class TaskRunner:
         _log.info(f"Resolving plugin: {cfg.plugin}")
         mk_proc = resolve(cfg.plugin)
         self.proc = mk_proc(**cfg.plugin_config)
-        self.product = product_for_plugin(self.proc, location=cfg.output_location, **cfg.product)
+        self.product = product_for_plugin(
+            self.proc, location=cfg.output_location, **cfg.product
+        )
         _log.info(f"Output product: {self.product}")
 
         if not from_sqs:
@@ -113,7 +116,11 @@ class TaskRunner:
                 return False
         return True
 
-    def tasks(self, tasks: List[str], ds_filters: Optional[str] = None,) -> Iterator[Task]:
+    def tasks(
+        self,
+        tasks: List[str],
+        ds_filters: Optional[str] = None,
+    ) -> Iterator[Task]:
         from ._cli_common import parse_all_tasks
 
         if len(tasks) == 0:
@@ -125,7 +132,10 @@ class TaskRunner:
         return self.rdr.stream(tiles, ds_filters=ds_filters)
 
     def dry_run(
-        self, tasks: List[str], check_exists: bool = True, ds_filters: Optional[str] = None
+        self,
+        tasks: List[str],
+        check_exists: bool = True,
+        ds_filters: Optional[str] = None,
     ) -> Iterator[TaskResult]:
         sink = self.sink
         overwrite = self._cfg.overwrite
@@ -211,7 +221,7 @@ class TaskRunner:
             aux: Optional[xr.Dataset] = None
 
             # if no rgba setting in cog_ops:overrides, no rgba tif as ouput
-            if 'overrides' in cfg.cog_opts and 'rgba' in cfg.cog_opts['overrides']:
+            if "overrides" in cfg.cog_opts and "rgba" in cfg.cog_opts["overrides"]:
                 rgba = proc.rgba(ds)
                 if rgba is not None:
                     aux = xr.Dataset(dict(rgba=rgba))
@@ -254,26 +264,31 @@ class TaskRunner:
             yield result
 
     def run(
-        self, tasks: Optional[List[str]] = None, 
-        sqs: Optional[str] = None, 
+        self,
+        tasks: Optional[List[str]] = None,
+        sqs: Optional[str] = None,
         ds_filters: Optional[str] = None,
-        apply_eodatasets3: Optional[bool] = False
+        apply_eodatasets3: Optional[bool] = False,
     ) -> Iterator[TaskResult]:
         cfg = self._cfg
         _log = self._log
 
         if tasks is not None:
             _log.info("Starting processing from task list")
-            return self._run(self.tasks(tasks, ds_filters=ds_filters), apply_eodatasets3)
+            return self._run(
+                self.tasks(tasks, ds_filters=ds_filters), apply_eodatasets3
+            )
         if sqs is not None:
             _log.info(
                 f"Processing from SQS: {sqs}, T:{cfg.job_queue_max_lease} M:{cfg.renew_safety_margin} seconds"
             )
             return self._run(
                 self.rdr.stream_from_sqs(
-                    sqs, visibility_timeout=cfg.job_queue_max_lease, ds_filters=ds_filters
+                    sqs,
+                    visibility_timeout=cfg.job_queue_max_lease,
+                    ds_filters=ds_filters,
                 ),
-                apply_eodatasets3
+                apply_eodatasets3,
             )
         raise ValueError("Must supply one of tasks= or sqs=")
 

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -42,7 +42,10 @@ def bin_generic(
 
 
 def bin_seasonal(
-    cells: Dict[Tuple[int, int], Cell], months: int, anchor: int, extract_single_season=False
+    cells: Dict[Tuple[int, int], Cell],
+    months: int,
+    anchor: int,
+    extract_single_season=False,
 ) -> Dict[Tuple[str, int, int], List[CompressedDataset]]:
     # mk_single_season_rules is different from mk_season_rules
     # because the mk_season_rules will split the whole year to 2/3/4 seasons
@@ -90,7 +93,7 @@ def bin_annual(
 
     return tasks
 
-    
+
 def mk_single_season_rules(months: int, anchor: int) -> Dict[int, str]:
     """
     Construct rules for a each year single season summary
@@ -245,9 +248,7 @@ def fuse_products(type_1: DatasetType, type_2: DatasetType) -> DatasetType:
     name = f"fused__{def_1['name']}__{def_2['name']}"
 
     fused_def["name"] = name
-    fused_def["metadata"] = {
-        "product": {"name": name}
-    }
+    fused_def["metadata"] = {"product": {"name": name}}
 
     if file_format is not None:
         fused_def["metadata"]["odc:file_format"] = file_format
@@ -304,7 +305,9 @@ def fuse_ds(
         label_title_doc_1 = label_title_doc_1.replace(doc_1["product"]["name"], "")
         label_title_doc_2 = label_title_doc_2.replace(doc_2["product"]["name"], "")
         if label_title_doc_1 != label_title_doc_2:
-            raise ValueError(f"Label/Title field {label_title_doc_1} is not the same as {label_title_doc_2}")
+            raise ValueError(
+                f"Label/Title field {label_title_doc_1} is not the same as {label_title_doc_2}"
+            )
 
         fused_doc["label"] = f"{product.name}{label_title_doc_1}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,13 @@ import pytest
 from mock import MagicMock
 import boto3
 from moto import mock_sqs
+from odc.stats.plugins import register
 from . import DummyPlugin
 
 TEST_DIR = pathlib.Path(__file__).parent.absolute()
 TEST_DATA_FOLDER = TEST_DIR / "data"
+
+# pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
@@ -31,8 +34,6 @@ def test_db_filter_path():
 
 @pytest.fixture
 def dummy_plugin_name():
-    from odc.stats.plugins import register
-
     name = "dummy-plugin"
     register(name, DummyPlugin)
     return name
@@ -69,3 +70,81 @@ def sqs_queue_by_name(aws_env):
         sqs.create_queue(QueueName=qname)
 
         yield qname
+
+
+@pytest.fixture
+def usgs_ls8_sr_definition():
+    definition = {
+        "name": "ls8_sr",
+        "description": "USGS Landsat 8 Collection 2 Level-2 \
+                        Surface Reflectance",
+        "metadata_type": "eo3",
+        "measurements": [
+            {
+                "name": "QA_PIXEL",
+                "dtype": "uint16",
+                "units": "bit_index",
+                "nodata": "1",
+                "flags_definition": {
+                    "snow": {
+                        "bits": 5,
+                        "values": {"0": "not_high_confidence", "1": "high_confidence"},
+                    },
+                    "clear": {"bits": 6, "values": {"0": False, "1": True}},
+                    "cloud": {
+                        "bits": 3,
+                        "values": {"0": "not_high_confidence", "1": "high_confidence"},
+                    },
+                    "water": {
+                        "bits": 7,
+                        "values": {"0": "land_or_cloud", "1": "water"},
+                    },
+                    "cirrus": {
+                        "bits": 2,
+                        "values": {"0": "not_high_confidence", "1": "high_confidence"},
+                    },
+                    "nodata": {"bits": 0, "values": {"0": False, "1": True}},
+                    "cloud_shadow": {
+                        "bits": 4,
+                        "values": {"0": "not_high_confidence", "1": "high_confidence"},
+                    },
+                    "dilated_cloud": {
+                        "bits": 1,
+                        "values": {"0": "not_dilated", "1": "dilated"},
+                    },
+                    "cloud_confidence": {
+                        "bits": [8, 9],
+                        "values": {"0": "none", "1": "low", "2": "medium", "3": "high"},
+                    },
+                    "cirrus_confidence": {
+                        "bits": [14, 15],
+                        "values": {
+                            "0": "none",
+                            "1": "low",
+                            "2": "reserved",
+                            "3": "high",
+                        },
+                    },
+                    "snow_ice_confidence": {
+                        "bits": [12, 13],
+                        "values": {
+                            "0": "none",
+                            "1": "low",
+                            "2": "reserved",
+                            "3": "high",
+                        },
+                    },
+                    "cloud_shadow_confidence": {
+                        "bits": [10, 11],
+                        "values": {
+                            "0": "none",
+                            "1": "low",
+                            "2": "reserved",
+                            "3": "high",
+                        },
+                    },
+                },
+            }
+        ],
+    }
+    return definition

--- a/tests/test-env-py38.yml
+++ b/tests/test-env-py38.yml
@@ -9,7 +9,7 @@ dependencies:
   - python=3.8
 
   # Datacube
-  - datacube>=1.8.6
+  - datacube>=1.8.7
 
   # odc.{aws,aio}: aiobotocore/boto3
   #  pin aiobotocore for easier resolution of dependencies

--- a/tests/test_gm_ls_bitmask.py
+++ b/tests/test_gm_ls_bitmask.py
@@ -4,28 +4,34 @@ import dask.array as da
 from odc.stats.plugins.gm_ls_bitmask import StatsGMLSBitmask
 import pytest
 import pandas as pd
-from .test_utils import usgs_ls8_sr_definition
 
 
 @pytest.fixture
 def dataset(usgs_ls8_sr_definition):
-    band_red = np.array([
-        [[255, 57], [20, 50]],
-        [[30, 0], [70, 80]],
-        [[25, 52], [0, 0]],
-    ])
+    band_red = np.array(
+        [
+            [[255, 57], [20, 50]],
+            [[30, 0], [70, 80]],
+            [[25, 52], [0, 0]],
+        ]
+    )
     cloud_mask = 0b0000_0000_0000_1100
     no_data = 0b0000_0000_0000_0001
-    band_pq = np.array([
-        [[0, 0], [0, no_data]],
-        [[1, 0], [0, 0]],
-        [[0, cloud_mask], [0, 0]],
-    ])
+    band_pq = np.array(
+        [
+            [[0, 0], [0, no_data]],
+            [[1, 0], [0, 0]],
+            [[0, cloud_mask], [0, 0]],
+        ]
+    )
 
     band_red = da.from_array(band_red, chunks=(3, -1, -1))
     band_pq = da.from_array(band_pq, chunks=(3, -1, -1))
 
-    tuples = [(np.datetime64(f"2000-01-01T0{i}"), np.datetime64(f"2000-01-01")) for i in range(3)]
+    tuples = [
+        (np.datetime64(f"2000-01-01T0{i}"), np.datetime64("2000-01-01"))
+        for i in range(3)
+    ]
     index = pd.MultiIndex.from_tuples(tuples, names=["time", "solar_day"])
     coords = {
         "x": np.linspace(10, 20, band_red.shape[2]),
@@ -33,14 +39,23 @@ def dataset(usgs_ls8_sr_definition):
         "spec": index,
     }
     pq_flags_definition = {}
-    for measurement in usgs_ls8_sr_definition['measurements']:
-        if measurement['name'] == "QA_PIXEL":
-            pq_flags_definition = measurement['flags_definition']
-    attrs = dict(units="bit_index", nodata="1", crs="epsg:32633", grid_mapping="spatial_ref", flags_definition=pq_flags_definition)
+    for measurement in usgs_ls8_sr_definition["measurements"]:
+        if measurement["name"] == "QA_PIXEL":
+            pq_flags_definition = measurement["flags_definition"]
+    attrs = dict(
+        units="bit_index",
+        nodata="1",
+        crs="epsg:32633",
+        grid_mapping="spatial_ref",
+        flags_definition=pq_flags_definition,
+    )
 
-    data_vars = {"band_red": (("spec", "y", "x"), band_red), "QA_PIXEL": (("spec", "y", "x"), band_pq, attrs)}
+    data_vars = {
+        "band_red": (("spec", "y", "x"), band_red),
+        "QA_PIXEL": (("spec", "y", "x"), band_pq, attrs),
+    }
     xx = xr.Dataset(data_vars=data_vars, coords=coords)
-    xx['band_red'].attrs['nodata'] = 0
+    xx["band_red"].attrs["nodata"] = 0
     return xx
 
 
@@ -48,19 +63,23 @@ def test_native_transform(dataset):
     gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975)
 
     xx = gm.native_transform(dataset)
-    expected_result = np.array([
-        [[255, 57], [0, 0]],
-        [[0, 0], [70, 80]],
-        [[25, 52], [0, 0]],
-    ])
+    expected_result = np.array(
+        [
+            [[255, 57], [0, 0]],
+            [[0, 0], [70, 80]],
+            [[25, 52], [0, 0]],
+        ]
+    )
     result = xx.compute()["band_red"].data
     assert (result == expected_result).all()
 
-    expected_result = np.array([
-        [[False, False], [False, False]],
-        [[False, False], [False, False]],
-        [[False, True], [False, False]],
-    ])
+    expected_result = np.array(
+        [
+            [[False, False], [False, False]],
+            [[False, False], [False, False]],
+            [[False, True], [False, False]],
+        ]
+    )
     result = xx.compute()["cloud_mask"].data
     assert (result == expected_result).all()
 
@@ -83,9 +102,12 @@ def test_fuser(dataset):
     result = xx.compute()["cloud_mask"].data
     assert (result == expected_result).all()
 
+
 def test_reduce(dataset):
     _ = pytest.importorskip("hdstats")
-    gm = StatsGMLSBitmask(bands=["band_red"], offset=-0.2, scale=0.00975, output_scale=100)
+    gm = StatsGMLSBitmask(
+        bands=["band_red"], offset=-0.2, scale=0.00975, output_scale=100
+    )
 
     xx = gm.native_transform(dataset)
     xx = gm.reduce(xx)
@@ -96,18 +118,14 @@ def test_reduce(dataset):
         ["band_red", "smad", "emad", "bcmad", "count"]
     )
 
-    assert (result["band_red"].dtype == np.uint16)
-    assert (result["emad"].dtype == np.uint16)
+    assert result["band_red"].dtype == np.uint16
+    assert result["emad"].dtype == np.uint16
 
-    expected_result = np.array(
-        [[116, 36], [48,  58]]
-    )
+    expected_result = np.array([[116, 36], [48, 58]])
     band_red = result["band_red"].data
     assert (band_red == expected_result).all()
 
-    expected_result = np.array(
-        [[112, 0], [0,  0]]
-    )
+    expected_result = np.array([[112, 0], [0, 0]])
     band_emad = result["emad"].data
     assert (band_emad == expected_result).all()
 
@@ -117,10 +135,17 @@ def test_reduce(dataset):
     count = result["count"].data
     assert (count == expected_result).all()
 
+
 def test_reduce_with_filters(dataset):
     _ = pytest.importorskip("hdstats")
-    mask_filters = [("closing", 2), ("dilation",1)]
-    gm = StatsGMLSBitmask(bands=["band_red"], filters=mask_filters, offset=-0.2, scale=0.00975, output_scale=100)
+    mask_filters = [("closing", 2), ("dilation", 1)]
+    gm = StatsGMLSBitmask(
+        bands=["band_red"],
+        filters=mask_filters,
+        offset=-0.2,
+        scale=0.00975,
+        output_scale=100,
+    )
 
     xx = gm.native_transform(dataset)
     xx = gm.reduce(xx)
@@ -131,15 +156,11 @@ def test_reduce_with_filters(dataset):
         ["band_red", "smad", "emad", "bcmad", "count"]
     )
 
-    expected_result = np.array(
-        [[229, 36], [48,  58]]
-    )
+    expected_result = np.array([[229, 36], [48, 58]])
     band_red = result["band_red"].data
     assert (band_red == expected_result).all()
 
-    expected_result = np.array(
-        [[0, 0], [0,  0]]
-    )
+    expected_result = np.array([[0, 0], [0, 0]])
     band_emad = result["emad"].data
     assert (band_emad == expected_result).all()
 
@@ -149,10 +170,17 @@ def test_reduce_with_filters(dataset):
     count = result["count"].data
     assert (count == expected_result).all()
 
+
 def test_aux_result_bands_to_match_inputs(dataset):
     _ = pytest.importorskip("hdstats")
-    aux_names=dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT")
-    gm = StatsGMLSBitmask(bands=["band_red"], aux_names=aux_names, offset=-0.2, scale=0.00975, output_scale=100)
+    aux_names = dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT")
+    gm = StatsGMLSBitmask(
+        bands=["band_red"],
+        aux_names=aux_names,
+        offset=-0.2,
+        scale=0.00975,
+        output_scale=100,
+    )
 
     xx = gm.native_transform(dataset)
     xx = gm.reduce(xx)

--- a/tests/test_mangroves.py
+++ b/tests/test_mangroves.py
@@ -1,35 +1,47 @@
-from functools import partial
 import numpy as np
 import xarray as xr
 import dask.array as da
 from odc.stats.plugins.mangroves import Mangroves
 import pytest
-import pandas as pd
 
 
 @pytest.fixture
 def dataset():
     band_1 = np.array(
         [
-            [[255, 57], [20, 50], [10, 15],
-             [30, 40], [65, 80], [20, 39],
-             [90, 52], [73, 98], [30, 40]],
+            [
+                [255, 57],
+                [20, 50],
+                [10, 15],
+                [30, 40],
+                [65, 80],
+                [20, 39],
+                [90, 52],
+                [73, 98],
+                [30, 40],
+            ],
         ]
     ).astype(np.uint8)
 
     band_2 = np.array(
         [
-            [[0, 1], [2, 2], [1, 2],
-             [2, 2], [2, 2], [2, 2],
-             [2, 2], [2, 2], [1, 1]],
+            [[0, 1], [2, 2], [1, 2], [2, 2], [2, 2], [2, 2], [2, 2], [2, 2], [1, 1]],
         ]
     ).astype(np.uint8)
 
     band_3 = np.array(
         [
-            [[-1849, 0], [-1851, 0], [0, 0],
-             [0, 5], [0, 0], [0, 0],
-             [0, 0], [0, 45], [0, 0]],
+            [
+                [-1849, 0],
+                [-1851, 0],
+                [0, 0],
+                [0, 5],
+                [0, 0],
+                [0, 0],
+                [0, 0],
+                [0, 45],
+                [0, 0],
+            ],
         ]
     ).astype(np.int16)
 
@@ -49,8 +61,9 @@ def dataset():
             band_1, dims=("time", "y", "x"), attrs={"nodata": 255}
         ),
         "qa": xr.DataArray(band_2, dims=("time", "y", "x")),
-        "wet_pc_10": xr.DataArray(band_3, dims=("time", "y", "x"),
-                                  attrs={"nodata": -9999}),
+        "wet_pc_10": xr.DataArray(
+            band_3, dims=("time", "y", "x"), attrs={"nodata": -9999}
+        ),
     }
     xx = xr.Dataset(data_vars=data_vars, coords=coords)
 
@@ -60,23 +73,19 @@ def dataset():
 def test_native_transform(dataset):
     mangroves = Mangroves()
     out_xx = mangroves.native_transform(dataset)
-    assert (out_xx==dataset).all()
+    assert (out_xx == dataset).all()
+
 
 def test_reduce(dataset):
     mangroves = Mangroves()
     yy = mangroves.reduce(dataset)
-    expected_results =  dataset.pv_pc_10.copy(True)
-    expected_results.data = np.array([[[255,   0],
-                                       [255,   2],
-                                       [  0,   1],
-                                       [  1,   2],
-                                       [  3,   3],
-                                       [  1,   2],
-                                       [  3,   2],
-                                       [  3,   3],
-                                       [  0,   0]]], dtype=np.uint8)
-    expected_results.attrs['nodata'] = 255
+    expected_results = dataset.pv_pc_10.copy(True)
+    expected_results.data = np.array(
+        [[[255, 0], [255, 2], [0, 1], [1, 2], [3, 3], [1, 2], [3, 2], [3, 3], [0, 0]]],
+        dtype=np.uint8,
+    )
+    expected_results.attrs["nodata"] = 255
     expected_results = expected_results.to_dataset(name="canopy_cover_class")
-    assert (yy.canopy_cover_class.dtype == np.uint8)
-    assert (yy.canopy_cover_class.attrs == expected_results.canopy_cover_class.attrs)
+    assert yy.canopy_cover_class.dtype == np.uint8
+    assert yy.canopy_cover_class.attrs == expected_results.canopy_cover_class.attrs
     assert (yy == expected_results).all()

--- a/tests/test_pq_bitmask.py
+++ b/tests/test_pq_bitmask.py
@@ -4,29 +4,34 @@ import dask.array as da
 from odc.stats.plugins.pq_bitmask import StatsPQLSBitmask
 import pytest
 import pandas as pd
-from copy import deepcopy
-from .test_utils import usgs_ls8_sr_definition
 
 
 @pytest.fixture
 def dataset(usgs_ls8_sr_definition):
-    band_red = np.array([
-        [[255, 57], [20, 50]],
-        [[30, 0], [70, 80]],
-        [[25, 52], [0, 0]],
-    ])
+    band_red = np.array(
+        [
+            [[255, 57], [20, 50]],
+            [[30, 0], [70, 80]],
+            [[25, 52], [0, 0]],
+        ]
+    )
     cloud_mask = 0b0000_0000_0001_1100
     no_data = 0b0000_0000_0000_0001
-    band_pq = np.array([
-        [[0, 0], [cloud_mask, no_data]],
-        [[no_data, 0], [0, 0]],
-        [[0, cloud_mask], [cloud_mask, 0]],
-    ])
+    band_pq = np.array(
+        [
+            [[0, 0], [cloud_mask, no_data]],
+            [[no_data, 0], [0, 0]],
+            [[0, cloud_mask], [cloud_mask, 0]],
+        ]
+    )
 
     band_red = da.from_array(band_red, chunks=(3, -1, -1))
     band_pq = da.from_array(band_pq, chunks=(3, -1, -1))
 
-    tuples = [(np.datetime64(f"2000-01-01T0{i}"), np.datetime64(f"2000-01-01")) for i in range(3)]
+    tuples = [
+        (np.datetime64(f"2000-01-01T0{i}"), np.datetime64("2000-01-01"))
+        for i in range(3)
+    ]
     index = pd.MultiIndex.from_tuples(tuples, names=["time", "solar_day"])
     coords = {
         "x": np.linspace(10, 20, band_red.shape[2]),
@@ -34,14 +39,23 @@ def dataset(usgs_ls8_sr_definition):
         "spec": index,
     }
     pq_flags_definition = {}
-    for measurement in usgs_ls8_sr_definition['measurements']:
-        if measurement['name'] == "QA_PIXEL":
-            pq_flags_definition = measurement['flags_definition']
-    attrs = dict(units="bit_index", nodata="1", crs="epsg:32633", grid_mapping="spatial_ref", flags_definition=pq_flags_definition)
+    for measurement in usgs_ls8_sr_definition["measurements"]:
+        if measurement["name"] == "QA_PIXEL":
+            pq_flags_definition = measurement["flags_definition"]
+    attrs = dict(
+        units="bit_index",
+        nodata="1",
+        crs="epsg:32633",
+        grid_mapping="spatial_ref",
+        flags_definition=pq_flags_definition,
+    )
 
-    data_vars = {"band_red": (("spec", "y", "x"), band_red), "QA_PIXEL": (("spec", "y", "x"), band_pq, attrs)}
+    data_vars = {
+        "band_red": (("spec", "y", "x"), band_red),
+        "QA_PIXEL": (("spec", "y", "x"), band_pq, attrs),
+    }
     xx = xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs)
-    xx['band_red'].attrs['nodata'] = 0
+    xx["band_red"].attrs["nodata"] = 0
     return xx
 
 
@@ -49,11 +63,13 @@ def dataset(usgs_ls8_sr_definition):
 def dataset_with_aerosol_band(dataset):
     aerosol_mask = 0b1100_0000
     no_data = 0b0000_0001
-    band_aerosol = np.array([
-        [[0, 0], [aerosol_mask, no_data]],
-        [[no_data, 0], [0, 0]],
-        [[aerosol_mask, 0], [0, 0]],
-    ])
+    band_aerosol = np.array(
+        [
+            [[0, 0], [aerosol_mask, no_data]],
+            [[no_data, 0], [0, 0]],
+            [[aerosol_mask, 0], [0, 0]],
+        ]
+    )
 
     band_aerosol = da.from_array(band_aerosol, chunks=(3, -1, -1))
 
@@ -63,11 +79,13 @@ def dataset_with_aerosol_band(dataset):
 
 @pytest.fixture
 def dataset_with_atmos_opacity_band(dataset):
-    band_atmos_opacity = np.array([
-        [[0, 0], [400, -9999]],
-        [[-9999, 0], [0, 0]],
-        [[900, 500], [200, 0]],
-    ])
+    band_atmos_opacity = np.array(
+        [
+            [[0, 0], [400, -9999]],
+            [[-9999, 0], [0, 0]],
+            [[900, 500], [200, 0]],
+        ]
+    )
 
     band_atmos_opacity = da.from_array(band_atmos_opacity, chunks=(3, -1, -1))
 
@@ -77,20 +95,35 @@ def dataset_with_atmos_opacity_band(dataset):
 
 def test_meaurements(dataset):
     filters = {
-        "clear_0_1_1": [("closing", 0),("opening", 1), ("dilation", 1)],
-        "clear_1_0_1": [("closing", 1),("opening", 0), ("dilation", 1)],
-        "clear_1_1_0": [("closing", 1),("opening", 1), ("dilation", 0)],
-        "clear_1_1_1": [("closing", 1),("opening", 1), ("dilation", 1)]
+        "clear_0_1_1": [("closing", 0), ("opening", 1), ("dilation", 1)],
+        "clear_1_0_1": [("closing", 1), ("opening", 0), ("dilation", 1)],
+        "clear_1_1_0": [("closing", 1), ("opening", 1), ("dilation", 0)],
+        "clear_1_1_1": [("closing", 1), ("opening", 1), ("dilation", 1)],
     }
     aerosol_filters = {
-        "clear_0_1_1_aerosol": [("closing", 0),("opening", 1), ("dilation", 1)],
-        "clear_1_0_1_aerosol": [("closing", 1),("opening", 0), ("dilation", 1)]
+        "clear_0_1_1_aerosol": [("closing", 0), ("opening", 1), ("dilation", 1)],
+        "clear_1_0_1_aerosol": [("closing", 1), ("opening", 0), ("dilation", 1)],
     }
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL", filters=filters, aerosol_filters=aerosol_filters)
+    pq = StatsPQLSBitmask(
+        pq_band="QA_PIXEL",
+        aerosol_band="SR_QA_AEROSOL",
+        filters=filters,
+        aerosol_filters=aerosol_filters,
+    )
 
-    expected_result = ("total", "clear", "clear_0_1_1", "clear_1_0_1", "clear_1_1_0", "clear_1_1_1", "clear_aerosol", "clear_0_1_1_aerosol", "clear_1_0_1_aerosol")
+    expected_result = (
+        "total",
+        "clear",
+        "clear_0_1_1",
+        "clear_1_0_1",
+        "clear_1_1_0",
+        "clear_1_1_1",
+        "clear_aerosol",
+        "clear_0_1_1_aerosol",
+        "clear_1_0_1_aerosol",
+    )
     measurements = pq.measurements
-    assert (measurements == expected_result)
+    assert measurements == expected_result
 
 
 def test_native_transform(dataset):
@@ -99,19 +132,23 @@ def test_native_transform(dataset):
     xx = pq.native_transform(dataset)
     tr_result = xx.compute()
 
-    expected_result = np.array([
-        [[True, True], [True, False]],
-        [[False, True], [True, True]],
-        [[True, True], [True, True]],
-    ])
+    expected_result = np.array(
+        [
+            [[True, True], [True, False]],
+            [[False, True], [True, True]],
+            [[True, True], [True, True]],
+        ]
+    )
     keeps = tr_result["keeps"].data
     assert (keeps == expected_result).all()
 
-    expected_result = np.array([
-        [[False, False], [True, False]],
-        [[False, False], [False, False]],
-        [[False, True], [True, False]],
-    ])
+    expected_result = np.array(
+        [
+            [[False, False], [True, False]],
+            [[False, False], [False, False]],
+            [[False, True], [True, False]],
+        ]
+    )
     erased_cloud = tr_result["erased"].data
     assert (erased_cloud == expected_result).all()
 
@@ -137,19 +174,13 @@ def test_reduce(dataset):
     xx = pq.reduce(xx)
     reduce_result = xx.compute()
 
-    assert set(reduce_result.data_vars.keys()) == set(
-        ["total", "clear"]
-    )
+    assert set(reduce_result.data_vars.keys()) == set(["total", "clear"])
 
-    expected_result = np.array(
-        [[2, 3], [3, 2]]
-    )
+    expected_result = np.array([[2, 3], [3, 2]])
     total = reduce_result["total"].data
     assert (total == expected_result).all()
 
-    expected_result = np.array(
-        [[2, 2], [1, 2]]
-    )
+    expected_result = np.array([[2, 2], [1, 2]])
     clear = reduce_result["clear"].data
     assert (clear == expected_result).all()
 
@@ -157,7 +188,7 @@ def test_reduce(dataset):
 def test_reduce_with_filter(dataset):
     filters = {
         "clear_1_1": [("opening", 1), ("dilation", 1)],
-        "clear_2_1_1": [("closing", 2), ("opening", 1), ("dilation", 1)]
+        "clear_2_1_1": [("closing", 2), ("opening", 1), ("dilation", 1)],
     }
     pq = StatsPQLSBitmask(filters=filters)
 
@@ -169,48 +200,42 @@ def test_reduce_with_filter(dataset):
         ["total", "clear", "clear_1_1", "clear_2_1_1"]
     )
 
-    expected_result = np.array(
-        [[2, 3], [3, 2]]
-    )
+    expected_result = np.array([[2, 3], [3, 2]])
     total = reduce_result["total"].data
     assert (total == expected_result).all()
 
-    expected_result = np.array(
-        [[2, 2], [1, 2]]
-    )
+    expected_result = np.array([[2, 2], [1, 2]])
     clear = reduce_result["clear"].data
     assert (clear == expected_result).all()
 
-    expected_result = np.array(
-        [[2, 3], [3, 2]]
-    )
+    expected_result = np.array([[2, 3], [3, 2]])
     clear_1_1 = reduce_result["clear_1_1"].data
     assert (clear_1_1 == expected_result).all()
 
-    expected_result = np.array(
-        [[0, 1], [1, 1]]
-    )
+    expected_result = np.array([[0, 1], [1, 1]])
     clear_2_1_1 = reduce_result["clear_2_1_1"].data
     assert (clear_2_1_1 == expected_result).all()
 
 
 def test_native_transform_for_aerosol(dataset_with_aerosol_band):
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL")
+    pq = StatsPQLSBitmask(pq_band="QA_PIXEL", aerosol_band="SR_QA_AEROSOL")
 
     xx = pq.native_transform(dataset_with_aerosol_band)
     tr_result = xx.compute()
 
-    expected_result = np.array([
-        [[False, False], [True, False]],
-        [[False, False], [False, False]],
-        [[True, False], [False, False]],
-    ])
+    expected_result = np.array(
+        [
+            [[False, False], [True, False]],
+            [[False, False], [False, False]],
+            [[True, False], [False, False]],
+        ]
+    )
     erased_aerosol = tr_result["erased_aerosol"].data
     assert (erased_aerosol == expected_result).all()
 
 
 def test_fuse_for_aerosol(dataset_with_aerosol_band):
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL")
+    pq = StatsPQLSBitmask(pq_band="QA_PIXEL", aerosol_band="SR_QA_AEROSOL")
 
     xx = pq.native_transform(dataset_with_aerosol_band)
     xx = xx.groupby("solar_day").map(pq.fuser)
@@ -224,7 +249,7 @@ def test_fuse_for_aerosol(dataset_with_aerosol_band):
 
 
 def test_reduce_for_aerosol(dataset_with_aerosol_band):
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL")
+    pq = StatsPQLSBitmask(pq_band="QA_PIXEL", aerosol_band="SR_QA_AEROSOL")
 
     xx = pq.native_transform(dataset_with_aerosol_band)
     xx = pq.reduce(xx)
@@ -234,27 +259,26 @@ def test_reduce_for_aerosol(dataset_with_aerosol_band):
         ["total", "clear", "clear_aerosol"]
     )
 
-    expected_result = np.array(
-        [[2, 2], [1, 2]]
-    )
+    expected_result = np.array([[2, 2], [1, 2]])
     clear = reduce_result["clear"].data
     assert (clear == expected_result).all()
 
-    expected_result = np.array(
-        [[1, 2], [1, 2]]
-    )
+    expected_result = np.array([[1, 2], [1, 2]])
     clear_aerosol = reduce_result["clear_aerosol"].data
     assert (clear_aerosol == expected_result).all()
 
 
 def test_reduce_for_aerosol_with_filter(dataset_with_aerosol_band):
-    filters = {
-        "clear_0_1_1": [("closing", 0), ("opening", 1), ("dilation", 1)]
-    }
+    filters = {"clear_0_1_1": [("closing", 0), ("opening", 1), ("dilation", 1)]}
     aerosol_filters = {
         "clear_0_1_1_aerosol": [("closing", 0), ("opening", 1), ("dilation", 1)]
     }
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_QA_AEROSOL", filters=filters, aerosol_filters=aerosol_filters)
+    pq = StatsPQLSBitmask(
+        pq_band="QA_PIXEL",
+        aerosol_band="SR_QA_AEROSOL",
+        filters=filters,
+        aerosol_filters=aerosol_filters,
+    )
 
     xx = pq.native_transform(dataset_with_aerosol_band)
     xx = pq.reduce(xx)
@@ -264,36 +288,34 @@ def test_reduce_for_aerosol_with_filter(dataset_with_aerosol_band):
         ["total", "clear", "clear_0_1_1", "clear_aerosol", "clear_0_1_1_aerosol"]
     )
 
-    expected_result = np.array(
-        [[2, 3], [3, 2]]
-    )
+    expected_result = np.array([[2, 3], [3, 2]])
     clear_1_1_0 = reduce_result["clear_0_1_1"].data
     assert (clear_1_1_0 == expected_result).all()
 
-    expected_result = np.array(
-        [[1, 3], [2, 2]]
-    )
+    expected_result = np.array([[1, 3], [2, 2]])
     clear_aerosol = reduce_result["clear_0_1_1_aerosol"].data
     assert (clear_aerosol == expected_result).all()
 
 
 def test_native_transform_for_atmos_opacity(dataset_with_atmos_opacity_band):
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_ATMOS_OPACITY")
+    pq = StatsPQLSBitmask(pq_band="QA_PIXEL", aerosol_band="SR_ATMOS_OPACITY")
 
     xx = pq.native_transform(dataset_with_atmos_opacity_band)
     tr_result = xx.compute()
 
-    expected_result = np.array([
-        [[False, False], [True, False]],
-        [[False, False], [False, False]],
-        [[True, True], [False, False]],
-    ])
+    expected_result = np.array(
+        [
+            [[False, False], [True, False]],
+            [[False, False], [False, False]],
+            [[True, True], [False, False]],
+        ]
+    )
     erased_aerosol = tr_result["erased_aerosol"].data
     assert (erased_aerosol == expected_result).all()
 
 
 def test_fuse_for_atmos_opacity(dataset_with_atmos_opacity_band):
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_ATMOS_OPACITY")
+    pq = StatsPQLSBitmask(pq_band="QA_PIXEL", aerosol_band="SR_ATMOS_OPACITY")
 
     xx = pq.native_transform(dataset_with_atmos_opacity_band)
     xx = xx.groupby("solar_day").map(pq.fuser)
@@ -307,7 +329,7 @@ def test_fuse_for_atmos_opacity(dataset_with_atmos_opacity_band):
 
 
 def test_reduce_for_atmos_opacity(dataset_with_atmos_opacity_band):
-    pq = StatsPQLSBitmask(pq_band = "QA_PIXEL", aerosol_band = "SR_ATMOS_OPACITY")
+    pq = StatsPQLSBitmask(pq_band="QA_PIXEL", aerosol_band="SR_ATMOS_OPACITY")
 
     xx = pq.native_transform(dataset_with_atmos_opacity_band)
     xx = pq.reduce(xx)
@@ -317,14 +339,10 @@ def test_reduce_for_atmos_opacity(dataset_with_atmos_opacity_band):
         ["total", "clear", "clear_aerosol"]
     )
 
-    expected_result = np.array(
-        [[2, 2], [1, 2]]
-    )
+    expected_result = np.array([[2, 2], [1, 2]])
     clear = reduce_result["clear"].data
     assert (clear == expected_result).all()
 
-    expected_result = np.array(
-        [[1, 2], [1, 2]]
-    )
+    expected_result = np.array([[1, 2], [1, 2]])
     clear_aerosol = reduce_result["clear_aerosol"].data
     assert (clear_aerosol == expected_result).all()

--- a/tests/test_stats_model.py
+++ b/tests/test_stats_model.py
@@ -92,8 +92,11 @@ def test_parse_all_tasks():
 
 def test_product_for_plugin():
     from odc.stats.model import product_for_plugin
+
     plugin = DummyPlugin(bands=("red", "green"))
-    product = product_for_plugin(plugin, location="file:///tmp/{product}/v{version_raw}")
+    product = product_for_plugin(
+        plugin, location="file:///tmp/{product}/v{version_raw}"
+    )
     assert product.name == DummyPlugin.NAME
     assert product.short_name == DummyPlugin.SHORT_NAME
     assert product.version == DummyPlugin.VERSION
@@ -102,7 +105,8 @@ def test_product_for_plugin():
     assert product.properties["odc:product_family"] == DummyPlugin.PRODUCT_FAMILY
     assert product.href == f"https://collections.dea.ga.gov.au/product/{product.name}"
 
-    product = product_for_plugin(plugin,
+    product = product_for_plugin(
+        plugin,
         "file:///tmp/{product}/v{version}",
         name="custom-name",
         short_name="custom-short-name",
@@ -123,4 +127,4 @@ def test_product_for_plugin():
     assert product.properties["odc:custom-key"] == 33
     assert product.href == f"https://custom-site.com/product/{product.name}"
 
-    assert product.region_code((1, 22)) == 'x01y22'
+    assert product.region_code((1, 22)) == "x01y22"

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,7 +1,13 @@
 import pytest
-from odc.stats._text import read_int, parse_slice, parse_range2d_int, \
-                            parse_yaml, parse_yaml_file_or_inline, \
-                            split_and_check, load_yaml_remote
+from odc.stats._text import (
+    read_int,
+    parse_slice,
+    parse_range2d_int,
+    parse_yaml,
+    parse_yaml_file_or_inline,
+    split_and_check,
+    load_yaml_remote,
+)
 
 
 def test_read_int():
@@ -30,7 +36,8 @@ b: foo
 
 
 def test_load_yaml_remote(httpserver):
-    httpserver.expect_request("/ga_ls_fc_pc_cyear_3.yaml").respond_with_data("""
+    httpserver.expect_request("/ga_ls_fc_pc_cyear_3.yaml").respond_with_data(
+        """
     a: 3
     b: foo
     """
@@ -58,7 +65,8 @@ def test_parse_slice():
     assert parse_slice("1:4:2") == s_[1:4:2]
     assert parse_slice("1::2") == s_[1::2]
 
+
 def test_parse_2d_range():
-    assert parse_range2d_int("1:2,3:4") == ((1,2),(3,4))
+    assert parse_range2d_int("1:2,3:4") == ((1, 2), (3, 4))
     with pytest.raises(ValueError):
         parse_range2d_int("1,2:3,4")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import pytest
 from datacube import Datacube
 from datacube.model import Dataset, DatasetType, metadata_from_doc
 from datacube.index.eo3 import prep_eo3
-from datacube.index.index import default_metadata_type_docs
+from datacube.index.abstract import default_metadata_type_docs
 from odc.stats.model import DateTimeRange
 from odc.stats.tasks import TaskReader
 from odc.stats.utils import (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,7 +19,7 @@ from odc.stats.utils import (
     season_binner,
     fuse_products,
     fuse_ds,
-    mk_single_season_rules
+    mk_single_season_rules,
 )
 
 from . import gen_compressed_dss
@@ -156,30 +156,52 @@ def test_season_binner():
     assert binner(datetime(2001, 1, 19)) == "2001-01--P1M"
 
 
-@pytest.mark.parametrize(
-    "months,anchor",
-    [(6, 1)]
-)
+@pytest.mark.parametrize("months,anchor", [(6, 1)])
 def test_bin_seasonal_mk_season_rules(months, anchor):
     season_rules = mk_season_rules(months, anchor)
-    assert {'01--P6M', '07--P6M'} == set(season_rules.values())
+    assert {"01--P6M", "07--P6M"} == set(season_rules.values())
 
 
 @pytest.fixture
 def fc_definition():
     definition = {
-        'name': 'ga_ls_fc_3',
-        'metadata': {
-            'product': {'name': 'ga_ls_fc_3'},
-            'properties': {'odc:file_format': 'GeoTIFF', 'odc:product_family': 'fc'}
+        "name": "ga_ls_fc_3",
+        "metadata": {
+            "product": {"name": "ga_ls_fc_3"},
+            "properties": {"odc:file_format": "GeoTIFF", "odc:product_family": "fc"},
         },
-        'description': 'Geoscience Australia Landsat Fractional Cover Collection 3',
-        'measurements': [
-            {'name': 'bs', 'dtype': 'uint8', 'units': 'percent', 'nodata': 255, 'aliases': ['bare']},
-            {'name': 'pv', 'dtype': 'uint8', 'units': 'percent', 'nodata': 255, 'aliases': ['green_veg']},
-            {'name': 'npv', 'dtype': 'uint8', 'units': 'percent', 'nodata': 255, 'aliases': ['dead_veg']},
-            {'name': 'ue', 'dtype': 'uint8', 'units': '1', 'nodata': 255, 'aliases': ['err']}],
-        'metadata_type': 'eo3'
+        "description": "Geoscience Australia Landsat Fractional Cover Collection 3",
+        "measurements": [
+            {
+                "name": "bs",
+                "dtype": "uint8",
+                "units": "percent",
+                "nodata": 255,
+                "aliases": ["bare"],
+            },
+            {
+                "name": "pv",
+                "dtype": "uint8",
+                "units": "percent",
+                "nodata": 255,
+                "aliases": ["green_veg"],
+            },
+            {
+                "name": "npv",
+                "dtype": "uint8",
+                "units": "percent",
+                "nodata": 255,
+                "aliases": ["dead_veg"],
+            },
+            {
+                "name": "ue",
+                "dtype": "uint8",
+                "units": "1",
+                "nodata": 255,
+                "aliases": ["err"],
+            },
+        ],
+        "metadata_type": "eo3",
     }
     return definition
 
@@ -187,46 +209,16 @@ def fc_definition():
 @pytest.fixture
 def wo_definition():
     definition = {
-        'name': 'ga_ls_wo_3',
-        'metadata': {
-            'product': {'name': 'ga_ls_wo_3'},
-            'properties': {'odc:file_format': 'GeoTIFF', 'odc:product_family': 'wo'}
+        "name": "ga_ls_wo_3",
+        "metadata": {
+            "product": {"name": "ga_ls_wo_3"},
+            "properties": {"odc:file_format": "GeoTIFF", "odc:product_family": "wo"},
         },
-        'description': 'Geoscience Australia Landsat Water Observations Collection 3',
-        'measurements': [{'name': 'water', 'dtype': 'uint8', 'units': '1', 'nodata': 1}],
-        'metadata_type': 'eo3'
-    }
-    return definition
-
-
-@pytest.fixture
-def usgs_ls8_sr_definition():
-    definition = {
-        'name': 'ls8_sr',
-        'description': 'USGS Landsat 8 Collection 2 Level-2 Surface Reflectance',
-        'metadata_type': 'eo3',
-        'measurements': [
-            {
-                'name': 'QA_PIXEL',
-                'dtype': 'uint16',
-                'units': 'bit_index',
-                'nodata': '1',
-                'flags_definition': {
-                    'snow': {'bits': 5, 'values': {'0': 'not_high_confidence', '1': 'high_confidence'}},
-                    'clear': {'bits': 6, 'values': {'0': False, '1': True}},
-                    'cloud': {'bits': 3, 'values': {'0': 'not_high_confidence', '1': 'high_confidence'}},
-                    'water': {'bits': 7, 'values': {'0': 'land_or_cloud', '1': 'water'}},
-                    'cirrus': {'bits': 2, 'values': {'0': 'not_high_confidence', '1': 'high_confidence'}},
-                    'nodata': {'bits': 0, 'values': {'0': False, '1': True}},
-                    'cloud_shadow': {'bits': 4, 'values': {'0': 'not_high_confidence', '1': 'high_confidence'}},
-                    'dilated_cloud': {'bits': 1, 'values': {'0': 'not_dilated', '1': 'dilated'}},
-                    'cloud_confidence': {'bits': [8, 9], 'values': {'0': 'none', '1': 'low', '2': 'medium', '3': 'high'}},
-                    'cirrus_confidence': {'bits': [14, 15], 'values': {'0': 'none', '1': 'low', '2': 'reserved', '3': 'high'}},
-                    'snow_ice_confidence': {'bits': [12, 13], 'values': {'0': 'none', '1': 'low', '2': 'reserved', '3': 'high'}},
-                    'cloud_shadow_confidence': {'bits': [10, 11], 'values': {'0': 'none', '1': 'low', '2': 'reserved', '3': 'high'}}
-                }
-            }
-        ]
+        "description": "Geoscience Australia Landsat Water Observations Collection 3",
+        "measurements": [
+            {"name": "water", "dtype": "uint8", "units": "1", "nodata": 1}
+        ],
+        "metadata_type": "eo3",
     }
     return definition
 
@@ -237,7 +229,9 @@ def dc():
 
 
 def test_fuse_products(wo_definition, fc_definition):
-    standard_metadata_types = {d["name"]: metadata_from_doc(d) for d in default_metadata_type_docs()}
+    standard_metadata_types = {
+        d["name"]: metadata_from_doc(d) for d in default_metadata_type_docs()
+    }
     eo3 = standard_metadata_types["eo3"]
 
     wo_product = DatasetType(eo3, wo_definition)
@@ -272,7 +266,9 @@ def _get_msr_paths(ds):
 
 
 def test_fuse_dss(wo_definition, fc_definition):
-    standard_metadata_types = {d["name"]: metadata_from_doc(d) for d in default_metadata_type_docs()}
+    standard_metadata_types = {
+        d["name"]: metadata_from_doc(d) for d in default_metadata_type_docs()
+    }
     eo3 = standard_metadata_types["eo3"]
 
     wo_product = DatasetType(eo3, wo_definition)
@@ -280,107 +276,171 @@ def test_fuse_dss(wo_definition, fc_definition):
     fused_product = fuse_products(wo_product, fc_product)
 
     wo_metadata = {
-        'id': 'e9fb6737-b93d-5cd9-bfe6-7e634abc9905',
-        'crs': 'epsg:32655',
-        'grids': {'default': {'shape': [7211, 8311], 'transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0]}},
-        'label': 'ga_ls_wo_3_091086_2020-04-04_final',
-        '$schema': 'https://schemas.opendatacube.org/dataset',
-        'lineage': {'source_datasets': {}},
-        'product': {'name': 'ga_ls_wo_3'},
-        'properties': {
-            'title': 'ga_ls_wo_3_091086_2020-04-04_final',
-            'eo:gsd': 30.0,
-            'created': '2021-03-09T23:22:42.130266Z',
-            'datetime': '2020-04-04T23:33:10.644420Z',
-            'proj:epsg': 32655,
-            'proj:shape': [7211, 8311],
-            'eo:platform': 'landsat-7',
-            'odc:product': 'ga_ls_wo_3',
-            'odc:producer': 'ga.gov.au',
-            'eo:instrument': 'ETM',
-            'eo:cloud_cover': 44.870310145260326,
-            'eo:sun_azimuth': 49.20198554,
-            'proj:transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0],
-            'landsat:wrs_row': 86,
-            'odc:file_format': 'GeoTIFF',
-            'odc:region_code': '091086',
-            'dtr:end_datetime': '2020-04-04T23:33:24.461679Z',
-            'eo:sun_elevation': 32.7056476,
-            'landsat:wrs_path': 91,
-            'dtr:start_datetime': '2020-04-04T23:32:56.662365Z',
-            'odc:product_family': 'wo',
-            'odc:dataset_version': '1.6.0',
-            'dea:dataset_maturity': 'final',
-            'odc:collection_number': 3,
-            'odc:naming_conventions': 'dea_c3',
-            'odc:processing_datetime': '2020-04-04T23:33:10.644420Z',
-            'landsat:landsat_scene_id': 'LE70910862020095ASA00',
-            'landsat:collection_number': 1,
-            'landsat:landsat_product_id': 'LE07_L1TP_091086_20200404_20200501_01_T1',
-            'landsat:collection_category': 'T1'},
-            'measurements': {'water': {'path': 'ga_ls_wo_3_091086_2020-04-04_final_water.tif'}
-        }
+        "id": "e9fb6737-b93d-5cd9-bfe6-7e634abc9905",
+        "crs": "epsg:32655",
+        "grids": {
+            "default": {
+                "shape": [7211, 8311],
+                "transform": [
+                    30.0,
+                    0.0,
+                    423285.0,
+                    0.0,
+                    -30.0,
+                    -4040385.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                ],
+            }
+        },
+        "label": "ga_ls_wo_3_091086_2020-04-04_final",
+        "$schema": "https://schemas.opendatacube.org/dataset",
+        "lineage": {"source_datasets": {}},
+        "product": {"name": "ga_ls_wo_3"},
+        "properties": {
+            "title": "ga_ls_wo_3_091086_2020-04-04_final",
+            "eo:gsd": 30.0,
+            "created": "2021-03-09T23:22:42.130266Z",
+            "datetime": "2020-04-04T23:33:10.644420Z",
+            "proj:epsg": 32655,
+            "proj:shape": [7211, 8311],
+            "eo:platform": "landsat-7",
+            "odc:product": "ga_ls_wo_3",
+            "odc:producer": "ga.gov.au",
+            "eo:instrument": "ETM",
+            "eo:cloud_cover": 44.870310145260326,
+            "eo:sun_azimuth": 49.20198554,
+            "proj:transform": [
+                30.0,
+                0.0,
+                423285.0,
+                0.0,
+                -30.0,
+                -4040385.0,
+                0.0,
+                0.0,
+                1.0,
+            ],
+            "landsat:wrs_row": 86,
+            "odc:file_format": "GeoTIFF",
+            "odc:region_code": "091086",
+            "dtr:end_datetime": "2020-04-04T23:33:24.461679Z",
+            "eo:sun_elevation": 32.7056476,
+            "landsat:wrs_path": 91,
+            "dtr:start_datetime": "2020-04-04T23:32:56.662365Z",
+            "odc:product_family": "wo",
+            "odc:dataset_version": "1.6.0",
+            "dea:dataset_maturity": "final",
+            "odc:collection_number": 3,
+            "odc:naming_conventions": "dea_c3",
+            "odc:processing_datetime": "2020-04-04T23:33:10.644420Z",
+            "landsat:landsat_scene_id": "LE70910862020095ASA00",
+            "landsat:collection_number": 1,
+            "landsat:landsat_product_id": "LE07_L1TP_091086_20200404_20200501_01_T1",
+            "landsat:collection_category": "T1",
+        },
+        "measurements": {
+            "water": {"path": "ga_ls_wo_3_091086_2020-04-04_final_water.tif"}
+        },
     }
 
     fc_metadata = {
-        'id': '41980746-4f17-5e0c-86a0-92cca8d3c99d',
-        'crs': 'epsg:32655',
-        'grids': {'default': {'shape': [7211, 8311], 'transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0]}},
-        'label': 'ga_ls_fc_3_091086_2020-04-04_final',
-        '$schema': 'https://schemas.opendatacube.org/dataset',
-        'product': {'name': 'ga_ls_fc_3'},
-        'properties': {
-            'title': 'ga_ls_fc_3_091086_2020-04-04_final',
-            'eo:gsd': 30.0,
-            'created': '2021-03-10T04:14:49.645196Z',
-            'datetime': '2020-04-04T23:33:10.644420Z',
-            'proj:epsg': 32655,
-            'proj:shape': [7211, 8311],
-            'eo:platform': 'landsat-7',
-            'odc:product': 'ga_ls_fc_3',
-            'odc:producer': 'ga.gov.au',
-            'eo:instrument': 'ETM',
-            'eo:cloud_cover': 44.870310145260326,
-            'eo:sun_azimuth': 49.20198554,
-            'proj:transform': [30.0, 0.0, 423285.0, 0.0, -30.0, -4040385.0, 0.0, 0.0, 1.0],
-            'landsat:wrs_row': 86,
-            'odc:file_format': 'GeoTIFF',
-            'odc:region_code': '091086',
-            'dtr:end_datetime': '2020-04-04T23:33:24.461679Z',
-            'eo:sun_elevation': 32.7056476,
-            'landsat:wrs_path': 91,
-            'dtr:start_datetime': '2020-04-04T23:32:56.662365Z',
-            'odc:product_family': 'fc',
-            'odc:dataset_version': '2.5.0',
-            'dea:dataset_maturity': 'final',
-            'odc:collection_number': 3,
-            'odc:naming_conventions': 'dea_c3',
-            'odc:processing_datetime': '2020-04-04T23:33:10.644420Z',
-            'landsat:landsat_scene_id': 'LE70910862020095ASA00',
-            'landsat:collection_number': 1,
-            'landsat:landsat_product_id': 'LE07_L1TP_091086_20200404_20200501_01_T1',
-            'landsat:collection_category': 'T1'},
-            'measurements': {'bs': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_bs.tif'},
-            'pv': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_pv.tif'},
-            'ue': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_ue.tif'},
-            'npv': {'path': 'ga_ls_fc_3_091086_2020-04-04_final_npv.tif'}
-        }
+        "id": "41980746-4f17-5e0c-86a0-92cca8d3c99d",
+        "crs": "epsg:32655",
+        "grids": {
+            "default": {
+                "shape": [7211, 8311],
+                "transform": [
+                    30.0,
+                    0.0,
+                    423285.0,
+                    0.0,
+                    -30.0,
+                    -4040385.0,
+                    0.0,
+                    0.0,
+                    1.0,
+                ],
+            }
+        },
+        "label": "ga_ls_fc_3_091086_2020-04-04_final",
+        "$schema": "https://schemas.opendatacube.org/dataset",
+        "product": {"name": "ga_ls_fc_3"},
+        "properties": {
+            "title": "ga_ls_fc_3_091086_2020-04-04_final",
+            "eo:gsd": 30.0,
+            "created": "2021-03-10T04:14:49.645196Z",
+            "datetime": "2020-04-04T23:33:10.644420Z",
+            "proj:epsg": 32655,
+            "proj:shape": [7211, 8311],
+            "eo:platform": "landsat-7",
+            "odc:product": "ga_ls_fc_3",
+            "odc:producer": "ga.gov.au",
+            "eo:instrument": "ETM",
+            "eo:cloud_cover": 44.870310145260326,
+            "eo:sun_azimuth": 49.20198554,
+            "proj:transform": [
+                30.0,
+                0.0,
+                423285.0,
+                0.0,
+                -30.0,
+                -4040385.0,
+                0.0,
+                0.0,
+                1.0,
+            ],
+            "landsat:wrs_row": 86,
+            "odc:file_format": "GeoTIFF",
+            "odc:region_code": "091086",
+            "dtr:end_datetime": "2020-04-04T23:33:24.461679Z",
+            "eo:sun_elevation": 32.7056476,
+            "landsat:wrs_path": 91,
+            "dtr:start_datetime": "2020-04-04T23:32:56.662365Z",
+            "odc:product_family": "fc",
+            "odc:dataset_version": "2.5.0",
+            "dea:dataset_maturity": "final",
+            "odc:collection_number": 3,
+            "odc:naming_conventions": "dea_c3",
+            "odc:processing_datetime": "2020-04-04T23:33:10.644420Z",
+            "landsat:landsat_scene_id": "LE70910862020095ASA00",
+            "landsat:collection_number": 1,
+            "landsat:landsat_product_id": "LE07_L1TP_091086_20200404_20200501_01_T1",
+            "landsat:collection_category": "T1",
+        },
+        "measurements": {
+            "bs": {"path": "ga_ls_fc_3_091086_2020-04-04_final_bs.tif"},
+            "pv": {"path": "ga_ls_fc_3_091086_2020-04-04_final_pv.tif"},
+            "ue": {"path": "ga_ls_fc_3_091086_2020-04-04_final_ue.tif"},
+            "npv": {"path": "ga_ls_fc_3_091086_2020-04-04_final_npv.tif"},
+        },
     }
 
     # paths get made absolute here
     # TODO: force paths to stay relative
-    wo_uris = ["s3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/086/2020/04/04/ga_ls_wo_3_091086_2020-04-04_final.stac-item.json"]
+    wo_uris = [
+        "s3://dea-public-data/derivative/ga_ls_wo_3/1-6-0/091/086/2020/04/04/\
+                ga_ls_wo_3_091086_2020-04-04_final.stac-item.json"
+    ]
     wo_ds = Dataset(wo_product, prep_eo3(wo_metadata), uris=wo_uris)
-    fc_uris = ["s3://dea-public-data/derivative/ga_ls_fc_3/2-5-0/091/086/2020/04/04/ga_ls_fc_3_091086_2020-04-04_final.stac-item.json"]
+    fc_uris = [
+        "s3://dea-public-data/derivative/ga_ls_fc_3/2-5-0/091/086/2020/04/04/\
+                ga_ls_fc_3_091086_2020-04-04_final.stac-item.json"
+    ]
     fc_ds = Dataset(fc_product, prep_eo3(fc_metadata), uris=fc_uris)
 
     fused_ds = fuse_ds(wo_ds, fc_ds, fused_product)
-    assert _get_msr_paths(fused_ds) == _get_msr_paths(fc_ds).union(_get_msr_paths(wo_ds))
+    assert _get_msr_paths(fused_ds) == _get_msr_paths(fc_ds).union(
+        _get_msr_paths(wo_ds)
+    )
     fused_ds = fuse_ds(wo_ds, fc_ds)
-    assert _get_msr_paths(fused_ds) == _get_msr_paths(fc_ds).union(_get_msr_paths(wo_ds))
+    assert _get_msr_paths(fused_ds) == _get_msr_paths(fc_ds).union(
+        _get_msr_paths(wo_ds)
+    )
 
     bad_metadata = deepcopy(fc_metadata)
-    bad_metadata["properties"]["datetime"] = '2020-04-03T23:33:10.644420Z'
+    bad_metadata["properties"]["datetime"] = "2020-04-03T23:33:10.644420Z"
     bad_ds = Dataset(fc_product, prep_eo3(bad_metadata), uris=fc_uris)
     with pytest.raises(ValueError):
         fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)
@@ -392,13 +452,13 @@ def test_fuse_dss(wo_definition, fc_definition):
         fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)
 
     bad_metadata = deepcopy(fc_metadata)
-    bad_metadata['grids']['default']['shape'] = [7212, 8311]
+    bad_metadata["grids"]["default"]["shape"] = [7212, 8311]
     bad_ds = Dataset(fc_product, prep_eo3(bad_metadata), uris=fc_uris)
     with pytest.raises(ValueError):
         fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)
 
     bad_metadata = deepcopy(fc_metadata)
-    bad_metadata['label'] += 'a'
+    bad_metadata["label"] += "a"
     bad_ds = Dataset(fc_product, prep_eo3(bad_metadata), uris=fc_uris)
     with pytest.raises(ValueError):
         fused_ds = fuse_ds(wo_ds, bad_ds, fused_product)


### PR DESCRIPTION
Aimed to gather all the configs to produce a summary product in one single yaml, to 

- improve the consistency from run to run, and between sandbox/devbox and k8s
- reduce the barrier for automation
- be easier for maintenance and not collecting bits and pieces from different repos just for getting a right config

Changes

- `save-tasks` and `run` loading configs from the same yaml
- sanity checks on what configs are allowed by the functionalities
- add `.pre-commit-config.yaml` and `black` in GitHub workflow
- all files got formatted by `black`

It should be back-compatible, no default behaviour change is intended or expected.

