### PR TITLE
Check plugin_config exists

### DIFF
--- a/odc/stats/_cli_run.py
+++ b/odc/stats/_cli_run.py
@@ -163,6 +163,9 @@ def run(
 
     _cfg.update(cfg_from_cli)
     if plugin_config is not None:
+        if "plugin_config" not in _cfg:
+            _cfg["plugin_config"] = {}
+
         _cfg["plugin_config"].update(plugin_config)
 
     if resampling is not None and len(resampling) > 0:


### PR DESCRIPTION
[In a previous commit](https://github.com/opendatacube/odc-stats/commit/f2dc88c2659afc0e8e4562b8f4c56152c6f63384#diff-5b681956f7a54b335ce27aba159cbaa1ecb47e7b78a17742bb943cb585f264b4L143) `plugin_config` was assigned directly, now it's updated - but fails if the key doesn't exist.

```
main plugin-config
main cli options --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/odc-stats/mangroves/ga_ls_mangrove_cover_fyear_3.yaml --location s3://dea-public-data-dev/derivative/ga_ls_mangrove_cover_fyear_3/2-0-2 --plugin-config {mangroves_extent: /tmp/artifacts/maximum_extent_of_mangroves_Apr2019.shp}
main [2022-06-26 13:22:34,909] {_cli_run.py:139} INFO - Config overrides: {'filedb': '/tmp/artifacts/mangroves_fy.db', 'threads': 2, 'memory_limit': '8Gi', 'output_location': 's3://dea-public-data-dev/derivative/ga_ls_mangrove_cover_fyear_3/2-0-2', 'heartbeat_filepath': '/tmp/stats-heartbeat.txt'}
main Traceback (most recent call last):
main   File "/usr/local/bin/odc-stats", line 8, in <module>
main     sys.exit(main())
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1130, in __call__
main     return self.main(*args, **kwargs)
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1055, in main
main     rv = self.invoke(ctx)
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1657, in invoke
main     return _process_result(sub_ctx.command.invoke(sub_ctx))
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
main     return ctx.invoke(self.callback, **ctx.params)
main   File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 760, in invoke
main     return __callback(*args, **kwargs)
main   File "/usr/local/lib/python3.8/dist-packages/odc/stats/_cli_run.py", line 143, in run
main     _cfg["plugin_config"].update(plugin_config)
main KeyError: 'plugin_config'
main Error: exit status 1
```