### PR TITLE
wofs and fc percentile plugin

### DIFF
--- a/odc/stats/plugins/fc_percentiles.py
+++ b/odc/stats/plugins/fc_percentiles.py
@@ -3,12 +3,12 @@ Fractional Cover Percentiles
 """
 from functools import partial
 from itertools import product
-from typing import Optional, Tuple
+from typing import Tuple, Dict, Iterable, Optional
 
 import numpy as np
 import xarray as xr
 from odc.algo import keep_good_only
-from odc.algo._masking import _fuse_mean_np, _fuse_or_np, _or_fuser, _xr_fuse
+from odc.algo._masking import _fuse_mean_np, _fuse_or_np, _xr_fuse, mask_cleanup
 from odc.algo._percentile import xr_quantile_bands
 
 from ._registry import StatsPluginInterface, register
@@ -23,12 +23,15 @@ class StatsFCP(StatsPluginInterface):
     VERSION = "0.0.2"
     PRODUCT_FAMILY = "fc_percentiles"
 
+    BAD_BITS_MASK = dict(cloud=(1 << 6), cloud_shadow=(1 << 5), terrain_shadow=(1 << 3))
+
     def __init__(
         self,
         max_sum_limit: Optional[int] = None,
         clip_range: Optional[Tuple] = None,
         ue_threshold: Optional[int] = None,
         count_valid: Optional[bool] = False,
+        cloud_filters: Dict[str, Iterable[Tuple[str, int]]] = None,
         **kwargs,
     ):
         super().__init__(input_bands=["water", "pv", "bs", "npv", "ue"], **kwargs)
@@ -37,6 +40,7 @@ class StatsFCP(StatsPluginInterface):
         self.clip_range = clip_range
         self.ue_threshold = ue_threshold
         self.count_valid = count_valid
+        self.cloud_filters = cloud_filters if cloud_filters is not None else {}
 
     @property
     def measurements(self) -> Tuple[str, ...]:
@@ -59,51 +63,52 @@ class StatsFCP(StatsPluginInterface):
         5. Drop the WOfS band
         """
 
-        water = xx.water & 0b1110_1111
+        # not mask against bit 4: terrain high slope
+        # Pick out the dry and wet pixels
+        valid = (xx["water"] & ~(1 << 4)) == 0
+        wet = (xx["water"] & ~(1 << 4)) == 128
+
+        # dilate both 'valid' and 'water'
+        for key, val in self.BAD_BITS_MASK.items():
+            if self.cloud_filters.get(key) is not None:
+                raw_mask = (xx["water"] & val) > 0
+                raw_mask = mask_cleanup(
+                    raw_mask, mask_filters=self.cloud_filters.get(key)
+                )
+                valid &= ~raw_mask
+                wet &= ~raw_mask
+
         xx = xx.drop_vars(["water"])
-
-        # Pick out the dry pixels
-        dry = water == 0
-
-        # Incrementally add to the valid band
-        valid = dry
 
         # Pick out the pixels that have an unmixing error of less than the threshold
         if self.ue_threshold is not None:
             # No QA
-            unmixing_error_lt_30 = xx.ue < self.ue_threshold
-            valid = valid & unmixing_error_lt_30
+            valid &= xx.ue < self.ue_threshold
         xx = xx.drop_vars(["ue"])
 
         # If there's a sum limit or clip range, implement these
         if self.max_sum_limit is not None or self.clip_range is not None:
-            sum_bands = None
+            sum_bands = 0
             for band in xx.data_vars.keys():
                 attributes = xx[band].attrs
                 mask = xx[band] == NODATA
                 band_data = keep_good_only(xx[band], ~mask, nodata=0)
 
                 if self.max_sum_limit is not None:
-                    if sum_bands is None:
-                        sum_bands = band_data
-                    else:
-                        sum_bands = sum_bands + band_data
+                    sum_bands = sum_bands + band_data
 
                 if self.clip_range is not None:
                     # No QA
-                    limit_min, limit_max = self.clip_range
-                    clipped = np.clip(xx[band], limit_min, limit_max)
+                    clipped = np.clip(xx[band], self.clip_range[0], self.clip_range[1])
                     # Set masked values back to NODATA
                     xx[band] = clipped.where(~mask, NODATA)
                     xx[band].attrs = attributes
 
             if self.max_sum_limit is not None:
-                sum_lt_limit = sum_bands < self.max_sum_limit
-                valid = valid & sum_lt_limit
+                valid &= sum_bands < self.max_sum_limit
 
         xx = keep_good_only(xx, valid, nodata=NODATA)
-
-        xx["wet"] = water == 128
+        xx["wet"] = wet
         xx["valid"] = valid
 
         return xx
@@ -131,15 +136,16 @@ class StatsFCP(StatsPluginInterface):
         xx = xx.drop_vars(["wet", "valid"])
 
         yy = xr_quantile_bands(xx, [0.1, 0.5, 0.9], nodata=NODATA)
-        is_ever_wet = _or_fuser(wet).squeeze(wet.dims[0], drop=True)
+        # wet and valid(dry) are mutually exclusive, here we keep good data
+        wet &= ~valid
+        is_ever_wet = (wet.sum(axis=0, dtype="int16") > 0).astype("uint8")
 
-        band, *bands = yy.data_vars.keys()
-        all_bands_valid = yy[band] != NODATA
-        for band in bands:
+        all_bands_valid = True
+        for band in yy.data_vars.keys():
             all_bands_valid &= yy[band] != NODATA
 
-        all_bands_valid = all_bands_valid.astype(np.uint8)
-        is_ever_wet = is_ever_wet.astype(np.uint8)
+        all_bands_valid = all_bands_valid.astype("uint8")
+
         yy["qa"] = 1 + all_bands_valid - is_ever_wet * (1 - all_bands_valid)
 
         if self.count_valid:

--- a/odc/stats/plugins/wofs.py
+++ b/odc/stats/plugins/wofs.py
@@ -3,23 +3,32 @@ Water Observations Summaries
 
 Water Observations Summaries are made up of:
 
-- `count_clear`: a count of every time a pixel was observed (not obscured by terrain or clouds)
+- `count_clear`: a count of every time a pixel was observed
+  (not obscured by terrain or clouds)
 - `count_wet`: a count of every time a pixel was observed and wet
 - `frequency`: what fraction of time (wet/clear) was the pixel wet
 
 The counts are stored as `int16` and the frequency as `float32`.
 
-There are two different Stats Plugin classes implemented in this module. The first generates summary data from
-individual water observations, and the second generates a summary of summaries, which is used when generating an all
+There are two different Stats Plugin classes implemented in this module.
+The first generates summary data from individual water observations,
+and the second generates a summary of summaries, which is used when generating an all
 of time summary from existing annual summaries.
 
 """
-from typing import Sequence, Tuple
+
+from typing import Tuple, Dict, Iterable
 import numpy as np
 import xarray as xr
-from datacube.model import Dataset
-from datacube.utils.geometry import GeoBox
-from odc.algo import safe_div, apply_numexpr, keep_good_only, binary_dilation
+from odc.algo import (
+    safe_div,
+    apply_numexpr,
+    keep_good_only,
+    mask_cleanup,
+    _xr_fuse,
+    _fuse_and_np,
+    _fuse_or_np,
+)
 from ._registry import StatsPluginInterface, register
 
 
@@ -27,7 +36,8 @@ class StatsWofs(StatsPluginInterface):
     """
     Generate a Summary of Water Observations data from individual observations
 
-    The summary is made up of counts of visible and visible and wet, and the frequency of visible and wet.
+    The summary is made up of counts of visible and visible and wet,
+    and the frequency of visible and wet.
 
     Output data types are:
     - `count_clear`: `int16`
@@ -42,12 +52,15 @@ class StatsWofs(StatsPluginInterface):
     VERSION = "1.6.0"
     PRODUCT_FAMILY = "wo_summary"
 
-    # these get padded out if dilation was requested
-    BAD_BITS_MASK = 0b0110_1000  # Cloud/Shadow + Terrain Shadow
+    # these get padded out if cloud_filter is not None
+    BAD_BITS_MASK = dict(cloud=(1 << 6), cloud_shadow=(1 << 5), terrain_shadow=(1 << 3))
 
-    def __init__(self, dilation: int = 0, **kwargs):
+    def __init__(
+        self, cloud_filters: Dict[str, Iterable[Tuple[str, int]]] = None, **kwargs
+    ):
         super().__init__(input_bands=["water"], **kwargs)
-        self._dilation = dilation  # number of pixels to pad around BAD pixels
+        # dilation scheme for cloud/shadow
+        self.cloud_filters = cloud_filters if cloud_filters is not None else {}
 
     @property
     def measurements(self) -> Tuple[str, ...]:
@@ -75,22 +88,35 @@ class StatsWofs(StatsPluginInterface):
 
         out:
           .bad<Bool>   - pixel should not be counted
-          .some<Bool>  - there is data (bad or good but not nodata)
+          .some<Bool>  - there is data (x.water & 0b11) == 0,
+                         to distinguish "count=0" resulted from "nodata"
+                         or "not up to the classification criteria"
           .dry<Bool>   - pixel has dry classification and is not ``bad``
           .wet<Bool>   - pixel has wet classification and is not ``bad``
         """
-        if self._dilation != 0:
-            xx["bad"] = binary_dilation(
-                (xx.water & self.BAD_BITS_MASK) > 0, self._dilation
-            ) | ((xx.water & 0b0111_1110) > 0)
-        else:
-            xx["bad"] = (xx.water & 0b0111_1110) > 0
 
-        # some = (x.water&3)==0, i.e. nodata==0 and non_contigous==0
-        xx["some"] = apply_numexpr("((water<<30)>>30)==0", xx, name="some")
-        xx["dry"] = xx.water == 0
-        xx["wet"] = xx.water == 128
-        xx = xx.drop_vars("water")
+        xx["bad"] = apply_numexpr(
+            "(water & (~(1<<7))) > 0", xx, dtype="bool", name="bad"
+        )
+        xx["some"] = apply_numexpr(
+            "((water<<30)>>30)==0", xx, dtype="bool", name="some"
+        )
+
+        # dilate both 'some' and 'bad'
+        for key, val in self.BAD_BITS_MASK.items():
+            if self.cloud_filters.get(key) is not None:
+                raw_mask = (xx["water"] & val) > 0
+                raw_mask = mask_cleanup(
+                    raw_mask, mask_filters=self.cloud_filters.get(key)
+                )
+                xx["some"] |= raw_mask
+                xx["bad"] |= raw_mask
+
+        xx["dry"] = apply_numexpr("(water==0) & (~bad)", xx, dtype="bool", name="dry")
+        xx["wet"] = apply_numexpr(
+            "(water==(1<<7)) & (~bad)", xx, dtype="bool", name="wet"
+        )
+        xx = xx.drop_vars(["water", "bad"])
         for dv in xx.data_vars.values():
             dv.attrs.pop("nodata", None)
 
@@ -99,24 +125,19 @@ class StatsWofs(StatsPluginInterface):
     @staticmethod
     def fuser(xx):
         """
-        xx.bad  -- don't count
         xx.wet  -- is wet
         xx.dry  -- is dry
         xx.some -- there was at least one non-nodata observation at that pixel
         """
-        from odc.algo._masking import _or_fuser
+        # both wet = T => wet = T
+        # both dry = T => dry = T
+        # either some = T => some = T
 
-        # Merge everything with OR first
-        xx = _or_fuser(xx)
+        wet = _xr_fuse(xx["wet"], _fuse_and_np, "wet")
+        dry = _xr_fuse(xx["dry"], _fuse_and_np, "dry")
+        some = _xr_fuse(xx["some"], _fuse_or_np, "some")
 
-        # Ensure all 3 bits are exclusive
-        #  bad=T, wet=?, dry=? => (wet'=F  , dry'=F)
-        #  bad=F, wet=T, dry=T => (wet'=F  , dry'=F)
-        #  else                => (wet'=wet, dry'=dry)
-        wet = apply_numexpr("wet & (~dry) & (~bad)", xx, dtype="bool")
-        dry = apply_numexpr("dry & (~wet) & (~bad)", xx, dtype="bool")
-
-        return xr.Dataset(dict(wet=wet, dry=dry, bad=xx.bad, some=xx.some))
+        return xr.Dataset(dict(wet=wet, dry=dry, some=some))
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         nodata = -999
@@ -156,8 +177,8 @@ class StatsWofsFullHistory(StatsPluginInterface):
     - `count_wet`: `int16`
     - `frequency`: `float32`
 
-    Special care is taken with no-data values, both to pass them through and when calculating the counts and
-    frequencies.
+    Special care is taken with no-data values, both to pass them through and
+    when calculating the counts and frequencies.
     """
 
     NAME = "ga_ls_wo_fq_myear_3"
@@ -184,8 +205,8 @@ class StatsWofsFullHistory(StatsPluginInterface):
         nodata = dtype.type(xx.count_clear.nodata)
 
         # `missing` is a record of all pixels that were never observed.
-        # Store it separately first, then substitute it back in after computing the counts and
-        # frequency.
+        # Store it separately first, then substitute it back in after
+        # computing the counts and frequency.
         missing = (xx.count_clear == xx.count_clear.nodata).all(axis=0)
         cc = apply_numexpr(
             "where(count_clear==nodata, 0, count_clear)",
@@ -213,7 +234,8 @@ class StatsWofsFullHistory(StatsPluginInterface):
             _nan=np.float32("nan"),
         )
 
-        # Finalise the *count* variables by re-inserting the no-data value based on `missing`
+        # Finalise the *count* variables by re-inserting
+        # the no-data value based on `missing`
         count_clear = apply_numexpr(
             "where(missing, nodata, cc)",
             _yy,

--- a/tests/test_fc_percentiles.py
+++ b/tests/test_fc_percentiles.py
@@ -157,6 +157,7 @@ def test_reduce(dataset):
     stats_fcp = StatsFCP(count_valid=True)
     xx = stats_fcp.native_transform(dataset)
     xx = xx.groupby("solar_day").map(partial(StatsFCP.fuser, None))
+    xx = xx.compute()
     xx = stats_fcp.reduce(xx)
 
     result = xx.compute()["band_1_pc_10"].data
@@ -165,7 +166,7 @@ def test_reduce(dataset):
     assert (result[1, 1] == 255).all()
 
     expected_result = np.array(
-        [[1, 0], [0, 1], [1, 1]],
+        [[1, 1], [0, 1], [1, 1]],
     )
     result = xx.compute()["qa"].data
     print(result)

--- a/tests/test_wofs.py
+++ b/tests/test_wofs.py
@@ -1,0 +1,90 @@
+from functools import partial
+import numpy as np
+import xarray as xr
+import dask.array as da
+from odc.stats.plugins.wofs import StatsWofs
+import pytest
+import pandas as pd
+
+
+@pytest.fixture
+def dataset():
+    band_1 = np.array(
+        [
+            [[0, (1 << 7)], [(1 << 7), 1], [(1 << 7), 1]],
+            [[0, (1 << 7) | (1 << 6) | (1 << 5)], [0, (1 << 1)], [(1 << 7), 1]],
+            [
+                [(1 << 7), (1 << 7) | (1 << 6) | (1 << 5)],
+                [(1 << 2) | (1 << 1), 0],
+                [(1 << 1), 1],
+            ],
+        ]
+    ).astype(np.uint8)
+
+    band_1 = da.from_array(band_1, chunks=(3, -1, -1))
+
+    tuples = [
+        (np.datetime64("2000-01-01T00"), np.datetime64("2000-01-01")),
+        (np.datetime64("2000-01-01T01"), np.datetime64("2000-01-01")),
+        (np.datetime64("2000-01-02T12"), np.datetime64("2000-01-02")),
+    ]
+    index = pd.MultiIndex.from_tuples(tuples, names=["time", "solar_day"])
+    coords = {
+        "x": np.linspace(10, 20, band_1.shape[2]),
+        "y": np.linspace(0, 5, band_1.shape[1]),
+        "spec": index,
+    }
+
+    data_vars = {
+        "water": xr.DataArray(band_1, dims=("spec", "y", "x"), attrs={"nodata": 0}),
+    }
+    xx = xr.Dataset(data_vars=data_vars, coords=coords)
+
+    return xx
+
+
+def test_native_transform(dataset):
+    stats_wofs = StatsWofs()
+    out_xx = stats_wofs.native_transform(dataset)
+    out_xx.load()
+    expected = np.array(
+        [
+            [[0b0100, 0b0010], [0b0010, 0], [0b0010, 0]],
+            [[0b0100, 1], [0b0100, 1], [0b0010, 0]],
+            [[0b0010, 1], [1, 0b0100], [1, 0]],
+        ]
+    )
+    assert (out_xx["class"] == expected).all()
+
+
+def test_fusing(dataset):
+    stats_wofs = StatsWofs()
+    out_xx = stats_wofs.native_transform(dataset)
+    out_xx = out_xx.groupby("solar_day").map(partial(StatsWofs.fuser))
+    out_xx.load()
+    expected = np.array(
+        [
+            [[0b0100, 0b0011], [0b0110, 1], [0b0010, 0]],
+            [[0b0010, 1], [1, 0b0100], [1, 0]],
+        ]
+    )
+    assert (out_xx["class"] == expected).all()
+
+
+def test_reduce(dataset):
+    stats_wofs = StatsWofs()
+    out_xx = stats_wofs.native_transform(dataset)
+    out_xx = out_xx.groupby("solar_day").map(partial(StatsWofs.fuser))
+    out_xx = stats_wofs.reduce(out_xx)
+    assert out_xx.count_wet.attrs.get("nodata", 0) == -999
+    assert out_xx.count_clear.attrs.get("nodata", 0) == -999
+    out_xx.load()
+    expected = np.array([[1, 0], [0, 0], [1, -999]])
+    assert (out_xx.count_wet == expected).all()
+    expected = np.array([[2, 0], [0, 1], [1, -999]])
+    assert (out_xx.count_clear == expected).all()
+    expected = np.array([[0.5, np.nan], [np.nan, 0.0], [1.0, np.nan]])
+    assert (
+        out_xx.frequency.where(~np.isnan(out_xx.frequency), -1)
+        == np.where(~np.isnan(expected), expected, -1)
+    ).all()


### PR DESCRIPTION
Changes
- add cloud/shadow dilation to wofs and fc percentile plugin.
- add unit test for wofs plugin.
- apply mask before reprojection in wofs plugin.
- fix a bug in fc percentile, where `dry` and `wet` should mutually exclusive after fusing by keeping `dry`.
- fix a bug in wofs, where `non-contiguity` should be treated constantly as `non-clear` in masking, fusing and summarising. 
- moderate refactor of fc percentile to remove too many local variables introduced by DEAfrica workflow.
- major refactor of wofs to reflect the logic applied in fusing and counting/summarising.

Note:
There is no test on cloud/shadow dilation since it'll require some larger datasets. It'll be done in either `stats-docker` workflow or here after I can copy/paste Toktam's solution on GeoMAD test.

My apologies that this is a slightly large PR, due to the fact that I was switching between these two plugins. 