### PR TITLE
support explicit transform path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
         if: |
           github.repository == 'opendatacube/odc-stats'
 
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
           verbose: false

--- a/odc/stats/plugins/_base.py
+++ b/odc/stats/plugins/_base.py
@@ -18,8 +18,8 @@ class StatsPluginInterface(ABC):
     def __init__(
         self,
         resampling: str = "bilinear",
-        input_bands: Sequence[str] = None,
-        chunks: Mapping[str, int] = None,
+        input_bands: Optional[Sequence[str]] = None,
+        chunks: Optional[Mapping[str, int]] = None,
         basis: Optional[str] = None,
         group_by: str = "solar_day",
         rgb_bands: Optional[Sequence[str]] = None,

--- a/odc/stats/plugins/_base.py
+++ b/odc/stats/plugins/_base.py
@@ -25,6 +25,7 @@ class StatsPluginInterface(ABC):
         rgb_bands: Optional[Sequence[str]] = None,
         rgb_clamp: Tuple[float, float] = (1.0, 3_000.0),
         transform_code: Optional[str] = None,
+        area_of_interest: Optional[Sequence[float]] = None,
     ):
         self.resampling = resampling
         self.input_bands = input_bands if input_bands is not None else []
@@ -34,6 +35,7 @@ class StatsPluginInterface(ABC):
         self.rgb_bands = rgb_bands
         self.rgb_clamp = rgb_clamp
         self.transform_code = transform_code
+        self.area_of_interest = area_of_interest
 
     @property
     @abstractmethod

--- a/odc/stats/proc.py
+++ b/odc/stats/proc.py
@@ -221,7 +221,10 @@ class TaskRunner:
             _log.debug("Building Dask Graph")
             ds = proc.reduce(
                 proc.input_data(
-                    task.datasets, task.geobox, transform_code=proc.transform_code
+                    task.datasets,
+                    task.geobox,
+                    transform_code=proc.transform_code,
+                    area_of_interest=proc.area_of_interest,
                 )
             )
 
@@ -242,7 +245,7 @@ class TaskRunner:
             _log.debug("Waiting for completion")
             cancelled = False
 
-            for (dt, t_now) in wait_for_future(cog, cfg.future_poll_interval, t0=t0):
+            for (dt, _) in wait_for_future(cog, cfg.future_poll_interval, t0=t0):
                 if cfg.heartbeat_filepath is not None:
                     self._register_heartbeat(cfg.heartbeat_filepath)
                 if tk:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     gdal
     fsspec>=2022.1.0
     fiona
+    rasterio>=1.3.2
 
 [options.entry_points]
 console_scripts =

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+--no-binary rasterio
 
 # for patch stats docker
 datacube>=1.8.7
@@ -16,6 +17,7 @@ pytest
 pytest-cov
 pytest-httpserver
 pytest-timeout
+rasterio>=1.3.2
 
 # for docs
 sphinx


### PR DESCRIPTION
To address the issue caused by multiple transform options available in `proj >= 8.0`. After the change, an explicit path chosen by the authority code will be passed to reproject (related pr https://github.com/opendatacube/odc-tools/pull/500). Currently the transform path with authority code `epsg:9688` is default with gdal. The purpose of supporting an explicit transform path is to maintain the data consistency and integrity, as well as being aware and alerted of the similar issue in the future. 

We have decided there is no need to reprocess the data with the old transform path (code `epsg:1150`), where GDA94 and WGS84 is deemed equivalent while with `epsg:9688` it is not. More infos and discussions were in the emails. Hence all the data of summary products will be reprojected with the current transform path `epsg:9688` thereafter. They'll be specified in the relative config files for production.
