### PR TITLE
make frequency all literal when input temporal range

### DIFF
--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -324,7 +324,10 @@ class SaveTasks:
         msg(f"Total of {n_tiles:,d} spatial tiles")
 
         if self._frequency == "all":
-            tasks = bin_full_history(cells, start=dt_range.start, end=dt_range.end)
+            if temporal_range is None:
+                tasks = bin_full_history(cells, start=dt_range.start, end=dt_range.end)
+            else:
+                tasks = bin_generic(cells, [temporal_range])
         elif self._frequency == "semiannual":
             tasks = bin_seasonal(cells, months=6, anchor=1)
         elif self._frequency == "seasonal":


### PR DESCRIPTION
To fix an issue raised by @supermarkion that when `temporal_range=YY-MM--PNY` is given, the datasets are still binned by `key=YY--P(N+1)Y`. It will result in the wrong metadata. Hence the change is to accommodate both situations where it requires "all datasets available till today" or "the datasets within the given period ".
