### PR TITLE
Add  the rolling-3months frequency option 

### DIFF
--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -51,7 +51,7 @@ CONFIG_ITEMS = [
     type=str,
     help=(
         "Specify temporal binning: "
-        "annual|annual-fy|semiannual|seasonal|calendar-seasons|rolling-3months|nov-mar|apr-oct|all"
+        "annual|annual-fy|semiannual|seasonal|quartely|3month-seasons|nov-mar|apr-oct|all"
     ),
 )
 @click.option("--env", "-E", type=str, help="Datacube environment name")
@@ -179,14 +179,15 @@ def save_tasks(
             "annual-fy",
             "semiannual",
             "seasonal",
-            "calendar-seasons",
+            "quartely",
+            "3month-seasons",
             "rolling-3months",
             "nov-mar",
             "apr-oct",
             "all",
         ):
             print(
-                f"""Frequency must be one of annual|annual-fy|semiannual|seasonal|calendar-seasons|rolling-3months|nov-mar|apr-oct|all
+                f"""Frequency must be one of annual|annual-fy|semiannual|seasonal|quartely|3month-seasons|rolling-3months|nov-mar|apr-oct|all
                 and not '{frequency}'""",
                 file=sys.stderr,
             )

--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -179,6 +179,8 @@ def save_tasks(
             "annual-fy",
             "semiannual",
             "seasonal",
+            "calendar-seasons",
+            "rolling-3months"
             "nov-mar",
             "apr-oct",
             "all",

--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -51,7 +51,7 @@ CONFIG_ITEMS = [
     type=str,
     help=(
         "Specify temporal binning: "
-        "annual|annual-fy|semiannual|seasonal|nov-mar|apr-oct|all"
+        "annual|annual-fy|semiannual|seasonal|calendar-seasons|rolling-3months|nov-mar|apr-oct|all"
     ),
 )
 @click.option("--env", "-E", type=str, help="Datacube environment name")

--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -180,13 +180,13 @@ def save_tasks(
             "semiannual",
             "seasonal",
             "calendar-seasons",
-            "rolling-3months"
+            "rolling-3months",
             "nov-mar",
             "apr-oct",
             "all",
         ):
             print(
-                f"""Frequency must be one of annual|annual-fy|semiannual|seasonal|nov-mar|apr-oct|all
+                f"""Frequency must be one of annual|annual-fy|semiannual|seasonal|calendar-seasons|rolling-3months|nov-mar|apr-oct|all
                 and not '{frequency}'""",
                 file=sys.stderr,
             )

--- a/odc/stats/_cli_save_tasks.py
+++ b/odc/stats/_cli_save_tasks.py
@@ -51,7 +51,7 @@ CONFIG_ITEMS = [
     type=str,
     help=(
         "Specify temporal binning: "
-        "annual|annual-fy|semiannual|seasonal|quartely|3month-seasons|nov-mar|apr-oct|all"
+        "annual|annual-fy|semiannual|seasonal|quartely|3month-seasons|rolling-3months|nov-mar|apr-oct|all"
     ),
 )
 @click.option("--env", "-E", type=str, help="Datacube environment name")
@@ -187,7 +187,8 @@ def save_tasks(
             "all",
         ):
             print(
-                f"""Frequency must be one of annual|annual-fy|semiannual|seasonal|quartely|3month-seasons|rolling-3months|nov-mar|apr-oct|all
+                f"""Frequency must be one of annual|annual-fy|semiannual|seasonal|
+                quartely|3month-seasons|rolling-3months|nov-mar|apr-oct|all
                 and not '{frequency}'""",
                 file=sys.stderr,
             )

--- a/odc/stats/_sqs.py
+++ b/odc/stats/_sqs.py
@@ -9,6 +9,7 @@ from .model import WorkTokenInterface
 
 class SQSWorkToken(WorkTokenInterface):
     def __init__(self, msg, timeout: int, t0: Optional[datetime] = None):
+        super().__init__()
         if t0 is None:
             t0 = self.now()
         self._msg = msg

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -328,7 +328,7 @@ class SaveTasks:
         elif self._frequency == "semiannual":
             tasks = bin_seasonal(cells, months=6, anchor=1)
         elif self._frequency == "seasonal":
-            tasks = bin_seasonal(cells, months=3, anchor=12)
+            tasks = bin_seasonal(cells, months=3, anchor=1)
         elif self._frequency == "nov-mar":
             tasks = bin_seasonal(cells, months=5, anchor=11, extract_single_season=True)
         elif self._frequency == "apr-oct":

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -336,8 +336,7 @@ class SaveTasks:
             anchor = int(temporal_range.start.strftime("%m"))
             tasks = bin_seasonal(cells, months=3, anchor=anchor)
         elif self._frequency == "rolling-3months":
-            anchor = int(temporal_range.start.strftime("%m"))
-            tasks = bin_rolling_seasonal(cells, months=3, anchor=anchor, interval=1)          
+            tasks = bin_rolling_seasonal(cells, temporal_range=temporal_range, months=3, interval=1)          
         elif self._frequency == "nov-mar":
             tasks = bin_seasonal(cells, months=5, anchor=11, extract_single_season=True)
         elif self._frequency == "apr-oct":

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -337,7 +337,7 @@ class SaveTasks:
             tasks = bin_seasonal(cells, months=3, anchor=anchor)
         elif self._frequency == "rolling-3months":
             anchor = int(temporal_range.start.strftime("%m"))
-            tasks = bin_rolling_seasonal(cells, months=3, anchor=anchor, interval=1)          
+            tasks = bin_rolling_seasonal(cells, months=3, anchor=anchor, interval=1)
         elif self._frequency == "nov-mar":
             tasks = bin_seasonal(cells, months=5, anchor=11, extract_single_season=True)
         elif self._frequency == "apr-oct":

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -336,7 +336,9 @@ class SaveTasks:
             anchor = int(temporal_range.start.strftime("%m"))
             tasks = bin_seasonal(cells, months=3, anchor=anchor)
         elif self._frequency == "rolling-3months":
-            tasks = bin_rolling_seasonal(cells, temporal_range=temporal_range, months=3, interval=1)          
+            tasks = bin_rolling_seasonal(
+                cells, temporal_range=temporal_range, months=3, interval=1
+            )
         elif self._frequency == "nov-mar":
             tasks = bin_seasonal(cells, months=5, anchor=11, extract_single_season=True)
         elif self._frequency == "apr-oct":

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -329,6 +329,11 @@ class SaveTasks:
             tasks = bin_seasonal(cells, months=6, anchor=1)
         elif self._frequency == "seasonal":
             tasks = bin_seasonal(cells, months=3, anchor=12)
+        elif self._frequency == "calendar-seasons":
+            tasks = bin_seasonal(cells, months=3, anchor=1)
+        elif self._frequency == "rolling-3months":
+            anchor = int(temporal_range.start.strftime("%m"))
+            tasks = bin_seasonal(cells, months=3, anchor=anchor)
         elif self._frequency == "nov-mar":
             tasks = bin_seasonal(cells, months=5, anchor=11, extract_single_season=True)
         elif self._frequency == "apr-oct":

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -337,7 +337,7 @@ class SaveTasks:
             tasks = bin_seasonal(cells, months=3, anchor=anchor)
         elif self._frequency == "rolling-3months":
             anchor = int(temporal_range.start.strftime("%m"))
-            tasks = bin_rolling_seasonal(cells, months=3, anchor=anchor, overlap=1)          
+            tasks = bin_rolling_seasonal(cells, months=3, anchor=anchor, interval=1)          
         elif self._frequency == "nov-mar":
             tasks = bin_seasonal(cells, months=5, anchor=11, extract_single_season=True)
         elif self._frequency == "apr-oct":

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -33,6 +33,7 @@ from .utils import (
     bin_full_history,
     bin_generic,
     bin_seasonal,
+    bin_rolling_seasonal,
     fuse_ds,
     fuse_products,
 )
@@ -329,11 +330,14 @@ class SaveTasks:
             tasks = bin_seasonal(cells, months=6, anchor=1)
         elif self._frequency == "seasonal":
             tasks = bin_seasonal(cells, months=3, anchor=12)
-        elif self._frequency == "calendar-seasons":
+        elif self._frequency == "quartely":
             tasks = bin_seasonal(cells, months=3, anchor=1)
-        elif self._frequency == "rolling-3months":
+        elif self._frequency == "3month-seasons":
             anchor = int(temporal_range.start.strftime("%m"))
             tasks = bin_seasonal(cells, months=3, anchor=anchor)
+        elif self._frequency == "rolling-3months":
+            anchor = int(temporal_range.start.strftime("%m"))
+            tasks = bin_rolling_seasonal(cells, months=3, anchor=anchor, overlap=1)          
         elif self._frequency == "nov-mar":
             tasks = bin_seasonal(cells, months=5, anchor=11, extract_single_season=True)
         elif self._frequency == "apr-oct":

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -75,7 +75,7 @@ def bin_rolling_seasonal(
     months: int,
     anchor: int,
     interval: int,
-    drop: bool = True,
+    drop = True,
 ) -> Dict[Tuple[str, int, int], List[CompressedDataset]]:
     """
     :param drop: Drop a season if it does not have the complete number of months.

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -75,7 +75,7 @@ def bin_rolling_seasonal(
     months: int,
     anchor: int,
     interval: int,
-    drop = True,
+    drop=True,
 ) -> Dict[Tuple[str, int, int], List[CompressedDataset]]:
     """
     :param drop: Drop a season if it does not have the complete number of months.

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -80,7 +80,7 @@ def bin_rolling_seasonal(
     """
     :param drop: Drop a season if it does not have the complete number of months.
     """
-    
+
     binner = rolling_season_binner(mk_rolling_season_rules(months, anchor, interval))
 
     tasks = {}
@@ -109,7 +109,6 @@ def bin_rolling_seasonal(
 
             for key in remove:
                 del grouped[key]
-
 
         for temporal_k, dss in grouped.items():
             if temporal_k != "":
@@ -205,7 +204,7 @@ def mk_rolling_season_rules(months: int, anchor: int, interval: int) -> Dict[int
     Construct rules for rolling seasons
     :param months: Length of a single season in months can be one of [1, 12]
     :param anchor: Start month of the first season can be one of [1, 12]
-    :param interval: Length in months between the start months for 2 consecutive seasons. 
+    :param interval: Length in months between the start months for 2 consecutive seasons.
     """
     assert 1 <= months <= 12
     assert 1 <= anchor <= 12
@@ -214,7 +213,7 @@ def mk_rolling_season_rules(months: int, anchor: int, interval: int) -> Dict[int
     rules = defaultdict(list)
 
     # Get the start months for each regular non-overlapping season.
-    regular_seasons = [anchor+i*months for i in range(12//months)]
+    regular_seasons = [anchor + i * months for i in range(12 // months)]
 
     start_month_first_season = regular_seasons[0]
     start_month_last_season = regular_seasons[-1]
@@ -225,12 +224,18 @@ def mk_rolling_season_rules(months: int, anchor: int, interval: int) -> Dict[int
             if m > 12:
                 m = m - 12
             if months == 12:
-                rules[m].extend([f"{start_month-12 if start_month > 12 else start_month:02d}--P1Y"])
+                rules[m].extend(
+                    [f"{start_month-12 if start_month > 12 else start_month:02d}--P1Y"]
+                )
             else:
-                rules[m].extend([f"{start_month-12 if start_month > 12 else start_month:02d}--P{months:d}M"])
+                rules[m].extend(
+                    [
+                        f"{start_month-12 if start_month > 12 else start_month:02d}--P{months:d}M"
+                    ]
+                )
 
         start_month += interval
-    
+
     return rules
 
 
@@ -272,7 +277,7 @@ def rolling_season_binner(rules: Dict[int, str]) -> Callable[[datetime], list]:
                   month of the season and ``N`` is a duration of the season in
                   months.
     """
-        
+
     _rules = defaultdict(list)
 
     for month in range(1, 12 + 1):
@@ -283,9 +288,14 @@ def rolling_season_binner(rules: Dict[int, str]) -> Callable[[datetime], list]:
         else:
             # Get the start month for each season.
             start_months = [(season, int(season.split("--")[0])) for season in seasons]
-            # Get the yoffset for each season. 
-            _rules[month].extend([(season, 0 if start_month <= month else -1) for season, start_month in start_months])
-    
+            # Get the yoffset for each season.
+            _rules[month].extend(
+                [
+                    (season, 0 if start_month <= month else -1)
+                    for season, start_month in start_months
+                ]
+            )
+
     def label(dt: datetime) -> list:
         # Get the rules that apply to the dt month.
         month_rules = _rules[dt.month]
@@ -302,7 +312,7 @@ def rolling_season_binner(rules: Dict[int, str]) -> Callable[[datetime], list]:
 
         return tuple(labels)
 
-    return  label
+    return label
 
 
 def dedup_s2_datasets(dss):

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -71,7 +71,6 @@ def bin_seasonal(
     return tasks
 
 
-
 def bin_rolling_seasonal(
     cells: Dict[Tuple[int, int], Cell],
     temporal_range,
@@ -79,7 +78,9 @@ def bin_rolling_seasonal(
     interval: int,
 ) -> Dict[Tuple[str, int, int], List[CompressedDataset]]:
 
-    binner = rolling_season_binner(mk_rolling_season_rules(temporal_range, months, interval))
+    binner = rolling_season_binner(
+        mk_rolling_season_rules(temporal_range, months, interval)
+    )
 
     tasks = {}
     for tidx, cell in cells.items():
@@ -188,22 +189,27 @@ def mk_rolling_season_rules(temporal_range, months, interval):
     Construct rules for rolling seasons
     :param temporal_range: Time range for which datasets have been loaded.
     :param months: Length of a single season in months can be one of [1, 12]
-    :param interval: Length in months between the start months for 2 consecutive seasons. 
+    :param interval: Length in months between the start months for 2 consecutive seasons.
     """
     assert 1 <= months <= 12
     assert 0 < interval < months
 
     season_start_interval = relativedelta(months=interval)
-    
+
     start_date = DateTimeRange(temporal_range).start
     end_date = DateTimeRange(temporal_range).end
 
     rules = {}
     season_start = start_date
-    while DateTimeRange(f'{season_start.strftime("%Y-%m-%d")}--P{months}M').end  <= end_date:
-        rules[f'{season_start.strftime("%Y-%m-%d")}--P{months}M'] = DateTimeRange(f'{season_start.strftime("%Y-%m-%d")}--P{months}M')
+    while (
+        DateTimeRange(f'{season_start.strftime("%Y-%m-%d")}--P{months}M').end
+        <= end_date
+    ):
+        rules[f'{season_start.strftime("%Y-%m-%d")}--P{months}M'] = DateTimeRange(
+            f'{season_start.strftime("%Y-%m-%d")}--P{months}M'
+        )
         season_start += season_start_interval
-        
+
     return rules
 
 
@@ -245,13 +251,14 @@ def rolling_season_binner(rules: Dict[int, str]) -> Callable[[datetime], list]:
                   month of the season and ``N`` is a duration of the season in
                   months.
 
-    """    
+    """
+
     def label(dt: datetime) -> list:
         labels = []
         for label, label_date_range in rules.items():
             if dt in label_date_range:
                 labels.append(label)
-        
+
         return tuple(labels)
 
     return label

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -198,7 +198,7 @@ def mk_rolling_season_rules(temporal_range, months, interval):
 
     start_date = temporal_range.start
     end_date = temporal_range.end
-S
+
     rules = {}
     season_start = start_date
     while (

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -195,8 +195,8 @@ def mk_rolling_season_rules(temporal_range, months, interval):
 
     season_start_interval = relativedelta(months=interval)
     
-    start_date = DateTimeRange(temporal_range).start
-    end_date = DateTimeRange(temporal_range).end
+    start_date = temporal_range.start
+    end_date = temporal_range.end
 
     rules = {}
     season_start = start_date

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,6 +9,7 @@ import dask.array as da
 import numpy as np
 from odc.stats.utils import CompressedDataset
 from odc.stats.plugins import StatsPluginInterface
+from odc.stats.model import DateTimeRange
 
 
 class DummyPlugin(StatsPluginInterface):
@@ -66,7 +67,21 @@ def gen_compressed_dss(n, dt0=datetime(2010, 1, 1, 11, 30, 27), step=timedelta(d
         yield CompressedDataset(UUID(int=i), dt)
         dt = dt + step
 
-
+        
+def gen_compressed_dss_2(temporal_range=DateTimeRange("2020--P2Y"), step=timedelta(days=1)):
+    if isinstance(step, int):
+        step = timedelta(days=step)
+        
+    start_date = temporal_range.start
+    end_date = temporal_range.end
+    
+    i = 0
+    while start_date <= end_date:
+        yield CompressedDataset(UUID(int=i), start_date)
+        start_date += step
+        i += 1
+        
+        
 def mk_time_coords(timestamps):
     data = np.asarray(timestamps, dtype="datetime64[ns]")
     return xr.DataArray(data=data, coords={"time": data}, dims=("time",), name="time")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -67,21 +67,23 @@ def gen_compressed_dss(n, dt0=datetime(2010, 1, 1, 11, 30, 27), step=timedelta(d
         yield CompressedDataset(UUID(int=i), dt)
         dt = dt + step
 
-        
-def gen_compressed_dss_2(temporal_range=DateTimeRange("2020--P2Y"), step=timedelta(days=1)):
+
+def gen_compressed_dss_2(
+    temporal_range=DateTimeRange("2020--P2Y"), step=timedelta(days=1)
+):
     if isinstance(step, int):
         step = timedelta(days=step)
-        
+
     start_date = temporal_range.start
     end_date = temporal_range.end
-    
+
     i = 0
     while start_date <= end_date:
         yield CompressedDataset(UUID(int=i), start_date)
         start_date += step
         i += 1
-        
-        
+
+
 def mk_time_coords(timestamps):
     data = np.asarray(timestamps, dtype="datetime64[ns]")
     return xr.DataArray(data=data, coords={"time": data}, dims=("time",), name="time")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,6 @@ from odc.stats.utils import (
     mk_season_rules,
     mk_rolling_season_rules,
     season_binner,
-    rolling_season_binner,
     fuse_products,
     fuse_ds,
     mk_single_season_rules,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ from odc.stats.utils import (
     mk_single_season_rules,
 )
 
-from . import gen_compressed_dss
+from . import gen_compressed_dss, gen_compressed_dss_2
 
 
 def test_stac(test_db_path):
@@ -163,44 +163,53 @@ def test_season_binner():
 
 
 def test_rolling_season_binner():
-    seasons_rules = defaultdict(
-        list,
-        {
-            1: ["01--P6M"],
-            2: ["01--P6M"],
-            3: ["01--P6M"],
-            4: ["01--P6M", "04--P6M"],
-            5: ["01--P6M", "04--P6M"],
-            6: ["01--P6M", "04--P6M"],
-            7: ["04--P6M", "07--P6M"],
-            8: ["04--P6M", "07--P6M"],
-            9: ["04--P6M", "07--P6M"],
-            10: ["07--P6M"],
-            11: ["07--P6M"],
-            12: ["07--P6M"],
-        },
+    temporal_range = DateTimeRange("2000-02--P6M")
+
+    seasons_rules = {
+        "2000-02-01--P3M": DateTimeRange(datetime(2000, 2, 1, 0, 0), "3M"),
+        "2000-03-01--P3M": DateTimeRange(datetime(2000, 3, 1, 0, 0), "3M"),
+        "2000-04-01--P3M": DateTimeRange(datetime(2000, 4, 1, 0, 0), "3M"),
+        "2000-05-01--P3M": DateTimeRange(datetime(2000, 5, 1, 0, 0), "3M"),
+    }
+
+    assert (
+        mk_rolling_season_rules(temporal_range, months=3, interval=1) == seasons_rules
     )
 
-    assert mk_rolling_season_rules(months=6, anchor=1, interval=3) == seasons_rules
+    temporal_range = DateTimeRange("2019-03--P2Y")
 
-    dss = list(gen_compressed_dss(100, dt0=datetime(2000, 1, 1), step=13))
+    dss = list(gen_compressed_dss_2(temporal_range=temporal_range, step=1))
+
     cells = {
         (0, 1): SimpleNamespace(
             dss=dss, geobox=None, idx=None, utc_offset=timedelta(seconds=0)
         )
     }
-    tasks_s = bin_rolling_seasonal(cells=cells, months=6, anchor=1, interval=3)
+
+    tasks_s = bin_rolling_seasonal(
+        cells=cells, temporal_range=temporal_range, months=6, interval=1
+    )
+
     task_keys = [
-        ("2000-01--P6M", 0, 1),
-        ("2000-04--P6M", 0, 1),
-        ("2000-07--P6M", 0, 1),
-        ("2001-01--P6M", 0, 1),
-        ("2001-04--P6M", 0, 1),
-        ("2001-07--P6M", 0, 1),
-        ("2002-01--P6M", 0, 1),
-        ("2002-04--P6M", 0, 1),
-        ("2002-07--P6M", 0, 1),
-        ("2003-01--P6M", 0, 1),
+        ("2019-03-01--P6M", 0, 1),
+        ("2019-04-01--P6M", 0, 1),
+        ("2019-05-01--P6M", 0, 1),
+        ("2019-06-01--P6M", 0, 1),
+        ("2019-07-01--P6M", 0, 1),
+        ("2019-08-01--P6M", 0, 1),
+        ("2019-09-01--P6M", 0, 1),
+        ("2019-10-01--P6M", 0, 1),
+        ("2019-11-01--P6M", 0, 1),
+        ("2019-12-01--P6M", 0, 1),
+        ("2020-01-01--P6M", 0, 1),
+        ("2020-02-01--P6M", 0, 1),
+        ("2020-03-01--P6M", 0, 1),
+        ("2020-04-01--P6M", 0, 1),
+        ("2020-05-01--P6M", 0, 1),
+        ("2020-06-01--P6M", 0, 1),
+        ("2020-07-01--P6M", 0, 1),
+        ("2020-08-01--P6M", 0, 1),
+        ("2020-09-01--P6M", 0, 1),
     ]
 
     assert task_keys == list(tasks_s.keys())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,7 +78,7 @@ def test_binning():
 
     tasks = bin_seasonal(cells, 6, 1)
     verify(tasks)
-    
+
     tasks = bin_seasonal(cells, 3, 1, 1)
     verify(tasks)
 
@@ -164,43 +164,49 @@ def test_season_binner():
 
 
 def test_rolling_season_binner():
-    seasons_rules = defaultdict(list,
-                {1: ['01--P6M'],
-                 2: ['01--P6M'],
-                 3: ['01--P6M'],
-                 4: ['01--P6M', '04--P6M'],
-                 5: ['01--P6M', '04--P6M'],
-                 6: ['01--P6M', '04--P6M'],
-                 7: ['04--P6M', '07--P6M'],
-                 8: ['04--P6M', '07--P6M'],
-                 9: ['04--P6M', '07--P6M'],
-                 10: ['07--P6M'],
-                 11: ['07--P6M'],
-                 12: ['07--P6M']})
+    seasons_rules = defaultdict(
+        list,
+        {
+            1: ["01--P6M"],
+            2: ["01--P6M"],
+            3: ["01--P6M"],
+            4: ["01--P6M", "04--P6M"],
+            5: ["01--P6M", "04--P6M"],
+            6: ["01--P6M", "04--P6M"],
+            7: ["04--P6M", "07--P6M"],
+            8: ["04--P6M", "07--P6M"],
+            9: ["04--P6M", "07--P6M"],
+            10: ["07--P6M"],
+            11: ["07--P6M"],
+            12: ["07--P6M"],
+        },
+    )
 
     assert mk_rolling_season_rules(months=6, anchor=1, interval=3) == seasons_rules
 
-
     dss = list(gen_compressed_dss(100, dt0=datetime(2000, 1, 1), step=13))
     cells = {
-            (0, 1): SimpleNamespace(
-                dss=dss, geobox=None, idx=None, utc_offset=timedelta(seconds=0)
-            )}
-    tasks_s = bin_rolling_seasonal(cells=cells, months=6, anchor=1, interval=3) 
-    task_keys = [('2000-01--P6M', 0, 1),
-                 ('2000-04--P6M', 0, 1),
-                 ('2000-07--P6M', 0, 1),
-                 ('2001-01--P6M', 0, 1),
-                 ('2001-04--P6M', 0, 1),
-                 ('2001-07--P6M', 0, 1),
-                 ('2002-01--P6M', 0, 1),
-                 ('2002-04--P6M', 0, 1),
-                 ('2002-07--P6M', 0, 1),
-                 ('2003-01--P6M', 0, 1)]
-    
+        (0, 1): SimpleNamespace(
+            dss=dss, geobox=None, idx=None, utc_offset=timedelta(seconds=0)
+        )
+    }
+    tasks_s = bin_rolling_seasonal(cells=cells, months=6, anchor=1, interval=3)
+    task_keys = [
+        ("2000-01--P6M", 0, 1),
+        ("2000-04--P6M", 0, 1),
+        ("2000-07--P6M", 0, 1),
+        ("2001-01--P6M", 0, 1),
+        ("2001-04--P6M", 0, 1),
+        ("2001-07--P6M", 0, 1),
+        ("2002-01--P6M", 0, 1),
+        ("2002-04--P6M", 0, 1),
+        ("2002-07--P6M", 0, 1),
+        ("2003-01--P6M", 0, 1),
+    ]
+
     assert task_keys == list(tasks_s.keys())
-    
-    
+
+
 @pytest.mark.parametrize("months,anchor", [(6, 1)])
 def test_bin_seasonal_mk_season_rules(months, anchor):
     season_rules = mk_season_rules(months, anchor)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from collections import defaultdict
 from types import SimpleNamespace
 from copy import deepcopy
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from collections import defaultdict
 from types import SimpleNamespace
 from copy import deepcopy
 
@@ -15,8 +16,11 @@ from odc.stats.utils import (
     bin_full_history,
     bin_generic,
     bin_seasonal,
+    bin_rolling_seasonal,
     mk_season_rules,
+    mk_rolling_season_rules,
     season_binner,
+    rolling_season_binner,
     fuse_products,
     fuse_ds,
     mk_single_season_rules,
@@ -73,6 +77,9 @@ def test_binning():
         assert set(ds.id for ds in dss1) == set(ds.id for ds in dss2)
 
     tasks = bin_seasonal(cells, 6, 1)
+    verify(tasks)
+    
+    tasks = bin_seasonal(cells, 3, 1, 1)
     verify(tasks)
 
 
@@ -156,6 +163,44 @@ def test_season_binner():
     assert binner(datetime(2001, 1, 19)) == "2001-01--P1M"
 
 
+def test_rolling_season_binner():
+    seasons_rules = defaultdict(list,
+                {1: ['01--P6M'],
+                 2: ['01--P6M'],
+                 3: ['01--P6M'],
+                 4: ['01--P6M', '04--P6M'],
+                 5: ['01--P6M', '04--P6M'],
+                 6: ['01--P6M', '04--P6M'],
+                 7: ['04--P6M', '07--P6M'],
+                 8: ['04--P6M', '07--P6M'],
+                 9: ['04--P6M', '07--P6M'],
+                 10: ['07--P6M'],
+                 11: ['07--P6M'],
+                 12: ['07--P6M']})
+
+    assert mk_rolling_season_rules(months=6, anchor=1, interval=3) == seasons_rules
+
+
+    dss = list(gen_compressed_dss(100, dt0=datetime(2000, 1, 1), step=13))
+    cells = {
+            (0, 1): SimpleNamespace(
+                dss=dss, geobox=None, idx=None, utc_offset=timedelta(seconds=0)
+            )}
+    tasks_s = bin_rolling_seasonal(cells=cells, months=6, anchor=1, interval=3) 
+    task_keys = [('2000-01--P6M', 0, 1),
+                 ('2000-04--P6M', 0, 1),
+                 ('2000-07--P6M', 0, 1),
+                 ('2001-01--P6M', 0, 1),
+                 ('2001-04--P6M', 0, 1),
+                 ('2001-07--P6M', 0, 1),
+                 ('2002-01--P6M', 0, 1),
+                 ('2002-04--P6M', 0, 1),
+                 ('2002-07--P6M', 0, 1),
+                 ('2003-01--P6M', 0, 1)]
+    
+    assert task_keys == list(tasks_s.keys())
+    
+    
 @pytest.mark.parametrize("months,anchor", [(6, 1)])
 def test_bin_seasonal_mk_season_rules(months, anchor):
     season_rules = mk_season_rules(months, anchor)


### PR DESCRIPTION
With the `rolling-3months` option, datasets are binned into 3 month seasons with an interval of one month between the start  months of 2 consecutive seasons. For example given the temporal range `2022-02--P6M` i.e. start date 1-Feb-2022 and end date 31-Aug-2022 the datasets are binned into the following seasons  Feb-Apr, Mar-May, Apr-Jun and May-Jul. 