### PR TITLE
upgrade packages version in the docker image

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.8.10
   - libgdal
-  - gdal
+  - gdal<3.6.2
   - proj
   - rasterio>=1.3.2
   - libpq

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -3,10 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8.10
-  - libgdal=3.5.1
-  - gdal=3.5.1
-  - proj=9.0.1
-  - rasterio=1.3.2
+  - libgdal
+  - gdal
+  - proj
+  - rasterio>=1.3.2
   - libpq
   - git
   - wget
@@ -111,12 +111,12 @@ dependencies:
   - scipy
   - sentry-sdk
   - setuptools-scm
-  - Shapely
+  - Shapely>=2.0
   - six
   - slicerator
   - snuggs
   - sortedcontainers
-  - SQLAlchemy
+  - SQLAlchemy<2.0
   - structlog
   - tblib
   - text-unidecode
@@ -130,7 +130,7 @@ dependencies:
   - urlpath
   - Werkzeug
   - wrapt
-  - xarray=2022.3.0
+  - xarray>=2023.1.0
   - yarl
   - zict
   - zipp

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,14 +1,14 @@
 
 --extra-index-url https://packages.dea.ga.gov.au/
-datacube[performance,s3]>=1.8.7
+datacube[performance,s3]>=1.8.11
 hdstats==0.1.8.post1
-odc-algo==0.2.4.dev3417
+odc-algo==0.2.4.dev3628
 odc-apps-cloud==0.2.1
 # For testing
 odc-apps-dc-tools==0.2.4
 odc-cloud==0.2.1
 odc-dscache==0.2.2
-odc-stac==0.3.0rc1
+odc-stac==0.3.5
 
 # odc-stac is in PyPI
 odc-stats[ows]

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -11,8 +11,8 @@ odc-stats --version
 
 echo "Test GeoMAD"
 
-odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/361982fc9c5fe8d5f91b2fc3f9e8327373d58048/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite geomad-cyear.db
-odc-stats run  --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/361982fc9c5fe8d5f91b2fc3f9e8327373d58048/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite geomad-cyear.db
+odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite geomad-cyear.db
+odc-stats run  --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite geomad-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls8c_nbart_gm_cyear_3_x49y24_2015--P1Y_final*.tif
 


### PR DESCRIPTION
- remove the pin on `gdal` family, we'd know if any version causes trouble by test workflow. The consistency is guaranteed by enforcing the transform code here https://github.com/GeoscienceAustralia/dea-config/pull/1096
- put into bounds for `xarray` and `shapely`, not back compatible, `sqlalchemy<2.0` required by `datacube-core`, `gdal==3.6.2` has issue on reading from `s3`