### PR TITLE
bust cache when update packages versions

### DIFF
--- a/.github/workflows/statistician-image.yml
+++ b/.github/workflows/statistician-image.yml
@@ -108,3 +108,4 @@ jobs:
           password: ${{ secrets.GADOCKERSVC_PASSWORD }}
           image_name: ${{ env.IMAGE_NAME }}
           image_tag: latest,${{ needs.set_tags.outputs.image_tag }}
+          build_extra_args: '{"--build-arg": "UPDATE_VERSION=${{ needs.set_tags.outputs.image_tag }}"}'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN micromamba create  -y -p /env -f /conf/env.yaml && \
 
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
+ARG UPDATE_VERSION=1
 COPY requirements.txt /conf/
 RUN micromamba run -p /env pip install --no-cache-dir \
     --no-build-isolation -r /conf/requirements.txt


### PR DESCRIPTION
resolve issue #87,  only use cache of `conda` env and always install the newest version of packages.