### PR TITLE
Updated gm plugin to make it faster to run for S2

### DIFF
--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -24,7 +24,9 @@ class StatsGM(StatsPluginInterface):
         mask_band: str,
         contiguity_band: Optional[str] = None,
         nodata_classes: Optional[Tuple[str, ...]] = None,
-        cloud_filters: Dict[Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]] = None,
+        cloud_filters: Dict[
+            Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]
+        ] = None,
         basis_band=None,
         aux_names: Dict[str, str] = None,
         resampling: str = "nearest",

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -5,7 +5,7 @@ from typing import Optional, Union, Tuple, Iterable, Dict
 import xarray as xr
 from odc.algo import geomedian_with_mads
 from ._registry import StatsPluginInterface, register
-from odc.algo import enum_to_bool, keep_good_only
+from odc.algo import enum_to_bool, erase_bad
 from odc.algo import mask_cleanup
 import logging
 
@@ -104,7 +104,7 @@ class StatsGM(StatsPluginInterface):
             xx = xx.drop_vars([self._mask_band] + [self._contiguity_band])
         else:
             xx = xx.drop_vars([self._mask_band])
-        xx = keep_good_only(xx, ~bad)
+        xx = erase_bad(xx, bad)
         return xx
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -88,10 +88,9 @@ class StatsGM(StatsPluginInterface):
 
         if self.cloud_filters is not None:
             for cloud_class, c_filter in self.cloud_filters.items():
-                if isinstance(cloud_class, tuple):
-                    cloud_mask = enum_to_bool(mask, cloud_class)
-                else:
-                    cloud_mask = enum_to_bool(mask, (cloud_class,))
+                if not isinstance(cloud_class, tuple):
+                    cloud_class = (cloud_class,)
+                cloud_mask = enum_to_bool(mask, cloud_class)
                 cloud_mask_buffered = mask_cleanup(cloud_mask, mask_filters=c_filter)
                 bad = cloud_mask_buffered | bad
         else:

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -24,7 +24,7 @@ class StatsGM(StatsPluginInterface):
         mask_band: str,
         contiguity_band: Optional[str] = None,
         nodata_classes: Optional[Tuple[str, ...]] = None,
-        cloud_filters: Dict[Tuple[str, ...], Iterable[Tuple[str, int]]] = None,
+        cloud_filters: Dict[Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]] = None,
         basis_band=None,
         aux_names: Dict[str, str] = None,
         resampling: str = "nearest",

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -92,8 +92,7 @@ class StatsGM(StatsPluginInterface):
                     cloud_mask = enum_to_bool(mask, cloud_class)
                 else:
                     cloud_mask = enum_to_bool(mask, (cloud_class,))
-                cloud_mask_buffered = mask_cleanup(
-                    cloud_mask, mask_filters=c_filter)
+                cloud_mask_buffered = mask_cleanup(cloud_mask, mask_filters=c_filter)
                 bad = cloud_mask_buffered | bad
         else:
             cloud_shadow_mask = enum_to_bool(mask, ("cloud", "shadow"))
@@ -149,7 +148,12 @@ class StatsGMS2(StatsGM):
     ):
         cloud_filters = (
             {
-                ("cloud shadows", "cloud medium probability", "cloud high probability", "thin cirrus"): self.DEFAULT_FILTER,
+                (
+                    "cloud shadows",
+                    "cloud medium probability",
+                    "cloud high probability",
+                    "thin cirrus",
+                ): self.DEFAULT_FILTER,
             }
             if cloud_filters is None
             else cloud_filters
@@ -245,7 +249,9 @@ class StatsGMLS(StatsGM):
 
     @property
     def measurements(self) -> Tuple[str, ...]:
-        return tuple(b for b in self.bands if b != self._contiguity_band) + self.aux_bands
+        return (
+            tuple(b for b in self.bands if b != self._contiguity_band) + self.aux_bands
+        )
 
 
 register("gm-ls", StatsGMLS)

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -1,7 +1,7 @@
 """
 Geomedian
 """
-from typing import Optional, Tuple, Iterable, Dict
+from typing import Optional, Union, Tuple, Iterable, Dict
 import xarray as xr
 from odc.algo import geomedian_with_mads
 from ._registry import StatsPluginInterface, register
@@ -142,7 +142,7 @@ class StatsGMS2(StatsGM):
         bands: Optional[Tuple[str, ...]] = None,
         mask_band: str = "SCL",
         nodata_classes: Optional[Tuple[str, ...]] = ("no data",),
-        cloud_filters: Dict[Tuple[str, ...], Iterable[Tuple[str, int]]] = None,
+        cloud_filters: Dict[Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]] = None,
         aux_names: Dict[str, str] = None,
         rgb_bands=None,
         **kwargs,
@@ -208,7 +208,7 @@ class StatsGMLS(StatsGM):
         mask_band: str = "fmask",
         contiguity_band: str = "nbart_contiguity",
         nodata_classes: Optional[Tuple[str, ...]] = ("nodata",),
-        cloud_filters: Dict[Tuple[str, ...], Iterable[Tuple[str, int]]] = None,
+        cloud_filters: Dict[Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]] = None,
         aux_names: Dict[str, str] = None,
         rgb_bands=None,
         **kwargs,

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -88,7 +88,7 @@ class StatsGM(StatsPluginInterface):
 
         if self.cloud_filters is not None:
             for cloud_class, c_filter in self.cloud_filters.items():
-                if type(cloud_class) is tuple:
+                if isinstance(cloud_class, tuple):
                     cloud_mask = enum_to_bool(mask, cloud_class)
                 else:
                     cloud_mask = enum_to_bool(mask, (cloud_class,))

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -142,7 +142,9 @@ class StatsGMS2(StatsGM):
         bands: Optional[Tuple[str, ...]] = None,
         mask_band: str = "SCL",
         nodata_classes: Optional[Tuple[str, ...]] = ("no data",),
-        cloud_filters: Dict[Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]] = None,
+        cloud_filters: Dict[
+            Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]
+        ] = None,
         aux_names: Dict[str, str] = None,
         rgb_bands=None,
         **kwargs,
@@ -208,7 +210,9 @@ class StatsGMLS(StatsGM):
         mask_band: str = "fmask",
         contiguity_band: str = "nbart_contiguity",
         nodata_classes: Optional[Tuple[str, ...]] = ("nodata",),
-        cloud_filters: Dict[Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]] = None,
+        cloud_filters: Dict[
+            Union[str, Tuple[str, ...]], Iterable[Tuple[str, int]]
+        ] = None,
         aux_names: Dict[str, str] = None,
         rgb_bands=None,
         **kwargs,


### PR DESCRIPTION
Changes made to remove hard-coded contiguity check and allow multiple cloud classes to be masked in the same data read.

This is still slower (~50% longer) and requires more memory to run than the version from before Jun 2022. Suggestions appreciated to improve the efficiency.

Tried to allow the case when cloud_filters is provided in the previous format but not sure if this will pass all tests.