### PR TITLE
remove early dask unpack

### DIFF
--- a/odc/stats/proc.py
+++ b/odc/stats/proc.py
@@ -229,7 +229,7 @@ class TaskRunner:
             )
 
             _log.debug("Submitting to Dask (%s)", task.location)
-            ds = client.persist(ds, fifo_timeout="1ms")
+            # ds = client.persist(ds, fifo_timeout="1ms")
 
             aux: Optional[xr.Dataset] = None
 


### PR DESCRIPTION
It's to test/address one of my theories on issue #100:  the early unpack triggered something unexpected in dask graph.

My second theory is that the node id in dask graph is not unique when there are many chunks.