### PR TITLE
revert gm resampling to default bilinear

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build-wheels:
     if: |
@@ -61,7 +65,10 @@ jobs:
   test-wheels:
     runs-on: ubuntu-latest
     container:
-      image: opendatacube/datacube-statistician:latest
+      image: ghcr.io/${{ github.repository }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     services:
       postgres:

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -29,7 +29,6 @@ class StatsGM(StatsPluginInterface):
         ] = None,
         basis_band=None,
         aux_names: Dict[str, str] = None,
-        resampling: str = "nearest",
         work_chunks: Tuple[int, int] = (400, 400),
         **kwargs,
     ):
@@ -44,7 +43,6 @@ class StatsGM(StatsPluginInterface):
         if nodata_classes is not None:
             nodata_classes = tuple(nodata_classes)
         self._nodata_classes = nodata_classes
-        self.resampling = resampling
         input_bands = self.bands
         if self._nodata_classes is not None:
             # NOTE: this ends up loading Mask band twice, once to compute
@@ -54,7 +52,6 @@ class StatsGM(StatsPluginInterface):
         super().__init__(
             input_bands=input_bands,
             basis=basis_band or self.bands[0],
-            resampling=self.resampling,
             **kwargs,
         )
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://packages.dea.ga.gov.au/
-datacube!=1.8.14
+datacube>=1.8.17
 # for pytest-depends
 deepdiff
 future_fstrings
@@ -7,7 +7,7 @@ mock
 moto
 networkx
 numpy
-odc-algo==0.2.4.dev3628
+odc-algo
 odc-stac
 
 # For tests
@@ -17,4 +17,4 @@ pytest-httpserver
 pytest-timeout
 
 # patch image
-xarray>=2023.1.0
+xarray>=2023.7.0

--- a/tests/test_gm_ls.py
+++ b/tests/test_gm_ls.py
@@ -177,7 +177,7 @@ def test_resampling(dataset):
 
     dataset = dataset.copy()
     stats_gmls = StatsGMLS(cloud_filters=mask_filters, nodata_classes=(-999,))
-    assert stats_gmls.resampling == "nearest"
+    assert stats_gmls.resampling == "bilinear"
 
 
 def test_no_data_value(monkeypatch):


### PR DESCRIPTION
As the title. We have an implementation of "largest cover" equivalent for `boolean` mask in `odc-algo` when the `resampling=bilinear`.  Hence all the values should be reprojected with `bilinear` except for discrete/categorical values, which is default for all stats plugins set in the base class.