### PR TITLE
amend conda resolve failure

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -46,7 +46,7 @@ dependencies:
   - dask-image
   - deepdiff
   - defusedxml
-  - distributed
+  - distributed>2023.3.0
   - docutils
   - fiona
   - Flask


### PR DESCRIPTION
weird enough that conda failed in version resolving now and then. `distributed==2023.3.0` got compatibility issue with the newest `numpy`, hence the lower bound.