### PR TITLE
allow manual tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ on:
       - '!docs/**'
       - '!k8s/**'
       - '!README.md'
+    tags:
+      - '**'
   workflow_run:
     workflows: ["Create a new tag"]
     types:

--- a/odc/stats/proc.py
+++ b/odc/stats/proc.py
@@ -229,7 +229,7 @@ class TaskRunner:
             )
 
             _log.debug("Submitting to Dask (%s)", task.location)
-            # ds = client.persist(ds, fifo_timeout="1ms")
+            ds = client.persist(ds, fifo_timeout="1ms")
 
             aux: Optional[xr.Dataset] = None
 


### PR DESCRIPTION
As the title.

The workflow fails accidentally and the cached wheel will be gone. In this case, the release will be triggered by manually tagging.

Add back persist, as it's proved irrelevant to issue #100 