### PR TITLE
fix geomedian bug

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - python=3.10
   - libgdal
-  - gdal>=3.7.3
+  - gdal>=3.8
   - proj
   - rasterio>=1.3.2
   - libpq

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://packages.dea.ga.gov.au/
 datacube[performance,s3]>=1.8.17
 hdstats==0.1.8.post1
-odc-algo @ git+https://github.com/opendatacube/odc-algo@851e782
+odc-algo @ git+https://github.com/opendatacube/odc-algo@d37fd41
 odc-apps-cloud==0.2.2
 # For testing
 odc-apps-dc-tools==0.2.12

--- a/tests/compare_data.sh
+++ b/tests/compare_data.sh
@@ -21,7 +21,7 @@ do
 	then g_name=$(echo $f | cut -d'/' -f3-)
 	else g_name=$(echo $f | cut -d'/' -f2-)
 	fi
-	gdalcompare.py -sds $S3_PREFIX$g_name $f > /dev/null
+	gdalcompare.py -sds -skip_binary $S3_PREFIX$g_name $f > /dev/null
 	if [[ $? -ge 1 ]]
 	then 
 		echo "ERROR: results different from the golden file $S3_PREFIX$g_name"


### PR DESCRIPTION
As the title.
Changes:
- install from new `odc-algo` head which fixed geomedian issue #100
- update gdal version for easier skipping binary diff (`gdal<3.7.2` always skip binary for non-local files)
- tolerate the binary level diff of files as different gdal versions generate slightly different file head.