### PR TITLE
Handle credentials rotation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ install_requires =
     datacube!=1.8.14
     distributed
     numpy
-    odc-cloud[ASYNC]
+    odc-cloud[ASYNC]>=0.2.5
     odc_algo
     odc_dscache>=0.2.2
     odc_io

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,6 +8,7 @@ moto
 networkx
 numpy
 odc-algo
+odc-cloud>=0.2.5
 odc-stac
 
 # For tests


### PR DESCRIPTION
Changes:

- removed the static credentials, let `boto3.client` handle the credentials rotation
- changed how `s3_client` (ref:https://github.com/opendatacube/odc-tools/pull/597) is managed on dask cluster, one for scheduler and one per work (among all threads rather than each per thread)