### PR TITLE
Construct tasks with stac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,5 +151,6 @@ jobs:
 
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
         if: |
           github.repository == 'opendatacube/odc-stats'
 
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: false

--- a/odc/stats/_stac_fetch.py
+++ b/odc/stats/_stac_fetch.py
@@ -16,7 +16,7 @@ def s3_fetch_dss(glob, s3=None):
     if s3 is None:
         s3 = S3Fetcher(aws_unsigned=True)
 
-    blobs = s3(o.url for o in s3_find_glob(glob, skip_check=True, s3=s3))
+    asset_urls = [o.url for o in s3_find_glob(glob, skip_check=True, s3=s3)]
+    blobs = s3(asset_urls)
     stacs = (bytes2stac(b.data) for b in blobs)
-
-    return stac2ds(stacs)
+    return stac2ds(stacs, asset_urls=asset_urls)

--- a/odc/stats/_stac_fetch.py
+++ b/odc/stats/_stac_fetch.py
@@ -16,7 +16,6 @@ def s3_fetch_dss(glob, s3=None):
     if s3 is None:
         s3 = S3Fetcher(aws_unsigned=True)
 
-    asset_urls = [o.url for o in s3_find_glob(glob, skip_check=True, s3=s3)]
-    blobs = s3(asset_urls)
+    blobs = s3(o.url for o in s3_find_glob(glob, skip_check=True, s3=s3))
     stacs = (bytes2stac(b.data) for b in blobs)
-    return stac2ds(stacs, asset_urls=asset_urls)
+    return stac2ds(stacs)

--- a/odc/stats/model.py
+++ b/odc/stats/model.py
@@ -411,7 +411,12 @@ class Task:
             if "fused" in dataset.type.name:
                 sources = [e["id"] for e in dataset.metadata.sources.values()]
                 platforms.append(dataset.metadata_doc["properties"]["eo:platform"])
-                instruments.append(dataset.metadata_doc["properties"]["eo:instrument"])
+                if isinstance(
+                    dataset.metadata_doc["properties"]["eo:instrument"], list
+                ):
+                    instruments += dataset.metadata_doc["properties"]["eo:instrument"]
+                else:
+                    instruments += [dataset.metadata_doc["properties"]["eo:instrument"]]
                 dataset_assembler.note_source_datasets(
                     self.product.classifier, *sources
                 )

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -123,8 +123,6 @@ def sanitize_products_str(products_str):
     2. Multiple same separators between the product names are treated as one
     3. Multiple different separators between the product names is respected by left-right order
     e.g., ga_ls8+-ga_ls7 -> separator is `+` as `+` proceeds `-` from left to right
-    4. It can NOT deal with the different combo of "+/-"
-    e.g., ga_ls8+ga_ls7-ga_fc
     """
     if re.search(r"s3://", products_str, flags=re.I) is None:
         pattern = re.compile(r"[\+-]{1,}")

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -261,9 +261,12 @@ class SaveTasks:
             dss = chain(dss, dss_stac)
 
         if group_size > 0:
-            products = [
-                dc.index.products.get_by_name(product) for product in indexed_products
-            ] + prod_stac
+            products = (
+                [dc.index.products.get_by_name(product) for product in indexed_products]
+                + prod_stac
+                if non_indexed_products != []
+                else []
+            )
 
             dss = cls.ds_align(dss, products, group_size + 1, fuse_dss)
 

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -136,7 +136,9 @@ def sanitize_products_str(products_str):
 
     if len(product_list) == 1:
         # indexed: True, not: False
-        return [(p, "s3://" not in p) for p in product_list], group_size
+        return [
+            (re.sub(r"^\s+|\s+$", "", p), "s3://" not in p) for p in product_list
+        ], group_size
     else:
         final_list = []
         for p in product_list:
@@ -144,7 +146,7 @@ def sanitize_products_str(products_str):
                 l, _ = sanitize_products_str(p)
                 final_list += l
             else:
-                final_list += [(p, False)]
+                final_list += [(re.sub(r"^\s+|\s+$", "", p), False)]
     return final_list, group_size
 
 

--- a/odc/stats/tasks.py
+++ b/odc/stats/tasks.py
@@ -259,12 +259,9 @@ class SaveTasks:
             dss = chain(dss, dss_stac)
 
         if group_size > 0:
-            products = (
-                [dc.index.products.get_by_name(product) for product in indexed_products]
-                + prod_stac
-                if non_indexed_products != []
-                else []
-            )
+            products = [
+                dc.index.products.get_by_name(product) for product in indexed_products
+            ] + (prod_stac if non_indexed_products != [] else [])
 
             dss = cls.ds_align(dss, products, group_size + 1, fuse_dss)
 

--- a/odc/stats/utils.py
+++ b/odc/stats/utils.py
@@ -342,7 +342,7 @@ def fuse_products(type_1: DatasetType, type_2: DatasetType) -> DatasetType:
         fused_def["metadata"]["odc:file_format"] = file_format
 
     fused_def["description"] = (
-        f"Fused products: {def_1['description']}, {def_2['description']}"
+        f"Fused products: {def_1.get('description', 'non_indexed_1')}, {def_2.get('description', 'non_indexed_2')}"
     )
     fused_def["measurements"] = def_1["measurements"] + def_2["measurements"]
     fused_def["metadata_type"] = def_1["metadata_type"]
@@ -388,8 +388,8 @@ def fuse_ds(
     if label_title_doc_1 is None or label_title_doc_2 is None:
         raise ValueError("No label or title field found found")
 
-    label_title_doc_1 = label_title_doc_1.replace(doc_1["product"]["name"], "")
-    label_title_doc_2 = label_title_doc_2.replace(doc_2["product"]["name"], "")
+    label_title_doc_1 = label_title_doc_1.replace(ds_1.product.name, "")
+    label_title_doc_2 = label_title_doc_2.replace(ds_2.product.name, "")
     if label_title_doc_1 != label_title_doc_2:
         raise ValueError(
             f"Label/Title field {label_title_doc_1} is not the same as {label_title_doc_2}"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,9 +7,9 @@ mock
 moto
 networkx
 numpy
-odc-algo
+odc-algo @ git+https://github.com/opendatacube/odc-algo@d37fd41
 odc-cloud>=0.2.5
-odc-stac
+odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
 
 # For tests
 pytest

--- a/tests/test_save_tasks.py
+++ b/tests/test_save_tasks.py
@@ -1,6 +1,7 @@
 import pytest
 
-from odc.stats.tasks import SaveTasks
+from odc.stats.tasks import sanitize_products_str, SaveTasks
+from odc.stats.model import DateTimeRange
 from datacube import Datacube
 
 
@@ -18,31 +19,140 @@ def dc():
     return Datacube(app="test")
 
 
+@pytest.fixture(
+    params=[
+        # union
+        (
+            "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3+-+-",
+            0,
+            14,
+            [("ga_ls8c_ard_3", True), ("ga_ls7e_ard_3", True)],
+        ),
+        # intersect/groupby time
+        (
+            "+-+ga_ls8c_ard_3+---++ga_ls7e_ard_3-+-+",
+            1,
+            0,
+            [("ga_ls8c_ard_3", True), ("ga_ls7e_ard_3", True)],
+        ),
+        # fc doesn't have datasets for ls7
+        (
+            "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3--+-ga_ls_fc_3-+-+",
+            0,
+            7,
+            [("ga_ls8c_ard_3", True), ("ga_ls7e_ard_3", True), ("ga_ls_fc_3", True)],
+        ),
+        # wo has dataset for all sensors
+        (
+            "-+-ga_ls8c_ard_3++++-ga_ls7e_ard_3+-+-ga_ls_wo_3-+-+",
+            2,
+            14,
+            [("ga_ls8c_ard_3", True), ("ga_ls7e_ard_3", True), ("ga_ls_wo_3", True)],
+        ),
+        # non indexed datasets
+        (
+            (
+                "--+++s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/+--+"
+                "s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/+++"
+                "ga_ls_wo_fq_cyear_3+---ga_ls_fc_pc_cyear+-++"
+            ),
+            3,
+            0,
+            [
+                ("s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/", False),
+                ("s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/", False),
+                ("ga_ls_wo_fq_cyear_3", True),
+                ("ga_ls_fc_pc_cyear", True),
+            ],
+        ),
+        (
+            (
+                "+++ga_ls_wo_fq_cyear_3+-+++s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/"
+                "+--+s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/"
+                "+---ga_ls_fc_pc_cyear+-++"
+            ),
+            3,
+            0,
+            [
+                ("ga_ls_wo_fq_cyear_3", True),
+                ("s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/", False),
+                ("s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/", False),
+                ("ga_ls_fc_pc_cyear", True),
+            ],
+        ),
+        (
+            (
+                "+++ga_ls_wo_fq_cyear_3+--+s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/"
+                "+---ga_ls_fc_pc_cyear+-+++s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/-+++"
+            ),
+            3,
+            0,
+            [
+                ("ga_ls_wo_fq_cyear_3", True),
+                ("s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/", False),
+                ("ga_ls_fc_pc_cyear", True),
+                ("s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/", False),
+            ],
+        ),
+        (
+            (
+                "+++ga_ls_wo_fq_cyear_3----ga_ls_fc_pc_cyear---+"
+                "s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/"
+                "--+++s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/-+++"
+            ),
+            0,
+            0,
+            [
+                ("ga_ls_wo_fq_cyear_3", True),
+                ("ga_ls_fc_pc_cyear", True),
+                ("s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/", False),
+                ("s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/", False),
+            ],
+        ),
+    ]
+)
+def product_str(request):
+    return request.param
+
+
 @pytest.fixture
-def product_str():
-    return {
-        0: "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3+-+-",
-        1: "+-+ga_ls8c_ard_3+---++ga_ls7e_ard_3-+-+",
-        2: "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3+-+-ga_ls_fc_3-+-+",
-        3: "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3+-+-ga_ls_wo_3-+-+",
-    }
+def indexed_product_str(product_str):
+    if "s3" not in product_str[0]:
+        return product_str
 
 
-def test_find_dss(dc, query, product_str):
-    for k, v in product_str.items():
-        dss = SaveTasks._find_dss(dc, v, query, fuse_dss=False)
-        dss = list(dss)
-        if k == 0:
-            # union
-            assert len(dss) == 14
-        elif k == 1:
-            # intersect/groupby time
-            assert len(dss) == 0
-        elif k == 2:
-            # fc doesn't have datasets for ls7
-            assert len(dss) == 7
-            assert len(dss[0]) >= 2
-        elif k == 3:
-            # wo has dataset for all sensors
-            assert len(dss) == 14
-            assert len(dss[0]) >= 2
+@pytest.fixture
+def s3_path():
+    return [
+        "s3://dea-public-data/derivative/ga_ls_tc_pc_cyear_3/1-0-0/",
+        "s3://dea-public-data/derivative/ga_ls_fc_pc_cyear_3/3-0-0/",
+    ]
+
+
+def test_sanitize_products_str(product_str):
+    product_list, group_size = sanitize_products_str(product_str[0])
+    assert product_list == product_str[-1]
+    assert group_size == product_str[1]
+
+
+def test_create_dss_by_stac(s3_path):
+    temporal_range = DateTimeRange("2010--P2Y")
+    tiles = ((35, 37), (32, 34))
+    dss, product = SaveTasks.create_dss_by_stac(
+        s3_path, tiles=tiles, temporal_range=temporal_range
+    )
+    dss = list(dss)
+    assert len(product) == len(s3_path)
+    assert len(dss) == 4 * 2 * len(s3_path)
+    for p, key in zip(product, s3_path):
+        assert p.name == key.split("/")[-3]
+    for d in dss:
+        with_uris = False
+        for key in s3_path:
+            with_uris |= key in d.uris[0]
+        assert with_uris
+
+
+def test_find_dss(dc, query, indexed_product_str):
+    dss = SaveTasks._find_dss(dc, indexed_product_str[0], query, {}, fuse_dss=False)
+    assert list(dss) == indexed_product_str[2]

--- a/tests/test_save_tasks.py
+++ b/tests/test_save_tasks.py
@@ -37,15 +37,15 @@ def dc():
         ),
         # fc doesn't have datasets for ls7
         (
-            "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3--+-ga_ls_fc_3-+-+",
-            0,
+            "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3+-+-ga_ls_fc_3-+-+",
+            1,
             7,
             [("ga_ls8c_ard_3", True), ("ga_ls7e_ard_3", True), ("ga_ls_fc_3", True)],
         ),
         # wo has dataset for all sensors
         (
-            "-+-ga_ls8c_ard_3++++-ga_ls7e_ard_3+-+-ga_ls_wo_3-+-+",
-            2,
+            "-+-ga_ls8c_ard_3-+++-ga_ls7e_ard_3+-+-ga_ls_wo_3-+-+",
+            1,
             14,
             [("ga_ls8c_ard_3", True), ("ga_ls7e_ard_3", True), ("ga_ls_wo_3", True)],
         ),
@@ -154,5 +154,8 @@ def test_create_dss_by_stac(s3_path):
 
 
 def test_find_dss(dc, query, indexed_product_str):
-    dss = SaveTasks._find_dss(dc, indexed_product_str[0], query, {}, fuse_dss=False)
-    assert len(list(dss)) == indexed_product_str[2]
+    if indexed_product_str is None:
+        pass
+    else:
+        dss = SaveTasks._find_dss(dc, indexed_product_str[0], query, {}, fuse_dss=False)
+        assert len(list(dss)) == indexed_product_str[2]

--- a/tests/test_save_tasks.py
+++ b/tests/test_save_tasks.py
@@ -155,4 +155,4 @@ def test_create_dss_by_stac(s3_path):
 
 def test_find_dss(dc, query, indexed_product_str):
     dss = SaveTasks._find_dss(dc, indexed_product_str[0], query, {}, fuse_dss=False)
-    assert list(dss) == indexed_product_str[2]
+    assert len(list(dss)) == indexed_product_str[2]

--- a/tests/test_save_tasks.py
+++ b/tests/test_save_tasks.py
@@ -138,14 +138,13 @@ def test_sanitize_products_str(product_str):
 def test_create_dss_by_stac(s3_path):
     temporal_range = DateTimeRange("2010--P2Y")
     tiles = ((35, 37), (32, 34))
-    dss, product = SaveTasks.create_dss_by_stac(
+    dss = SaveTasks.create_dss_by_stac(
         s3_path, tiles=tiles, temporal_range=temporal_range
     )
     dss = list(dss)
-    assert len(product) == len(s3_path)
     assert len(dss) == 4 * 2 * len(s3_path)
-    for p, key in zip(product, s3_path):
-        assert p.name == key.split("/")[-3]
+    products = list(set([d.product for d in dss]))
+    assert len(products) == len(s3_path)
     for d in dss:
         with_uris = False
         for key in s3_path:


### PR DESCRIPTION
As the tile.

- take s3 paths and product names as input to construct task
- enable mixed inputs of s3 paths and product names
- fuse datasets and products properly when the datasets are constructed from stac

relevant change:
https://github.com/opendatacube/odc-stac/pull/152