### PR TITLE
Fix mangroves and wo plugins

### DIFF
--- a/odc/stats/plugins/wofs.py
+++ b/odc/stats/plugins/wofs.py
@@ -46,9 +46,11 @@ class StatsWofs(StatsPluginInterface):
     PRODUCT_FAMILY = "wo_summary"
 
     # these get padded out if dilation was requested
-    BAD_BITS_MASK = dict(
-        cloud=(1 << 6), cloud_shadow=(1 << 5), terrain_shadow=(1 << 3)
-    )  # Cloud/Shadow + Terrain Shadow
+    BAD_BITS_MASK = {
+        "cloud": (1 << 6),
+        "cloud_shadow": (1 << 5),
+        "terrain_shadow": (1 << 3),
+    }  # Cloud/Shadow + Terrain Shadow
 
     def __init__(
         self, cloud_filters: Dict[str, Iterable[Tuple[str, int]]] = None, **kwargs
@@ -138,11 +140,11 @@ class StatsWofs(StatsPluginInterface):
         count_clear = keep_good_only(count_clear, is_ok)
 
         return xr.Dataset(
-            dict(
-                count_wet=count_wet,
-                count_clear=count_clear,
-                frequency=frequency,
-            )
+            {
+                "count_wet": count_wet,
+                "count_clear": count_clear,
+                "frequency": frequency,
+            }
         )
 
 
@@ -207,7 +209,7 @@ class StatsWofsFullHistory(StatsPluginInterface):
             nodata=nodata,
         ).sum(axis=0, dtype=dtype)
 
-        _yy = xr.Dataset(dict(cc=cc, cw=cw, missing=missing))
+        _yy = xr.Dataset({"cc": cc, "cw": cw, "missing": missing})
 
         frequency = apply_numexpr(
             "where(cc==0, _nan, (_1*cw)/(_1*cc))",
@@ -236,9 +238,10 @@ class StatsWofsFullHistory(StatsPluginInterface):
 
         count_clear.attrs["nodata"] = int(nodata)
         count_wet.attrs["nodata"] = int(nodata)
+        frequency.attrs["nodata"] = np.nan
 
         yy = xr.Dataset(
-            dict(count_clear=count_clear, count_wet=count_wet, frequency=frequency)
+            {"count_clear": count_clear, "count_wet": count_wet, "frequency": frequency}
         )
         return yy
 

--- a/tests/test_mangroves.py
+++ b/tests/test_mangroves.py
@@ -1,8 +1,70 @@
 import numpy as np
 import xarray as xr
 import dask.array as da
+import os
 from odc.stats.plugins.mangroves import Mangroves
+import tempfile
+import json
+import fiona
+from fiona.crs import CRS
+from datacube.utils.geometry import GeoBox
+from affine import Affine
 import pytest
+
+
+@pytest.fixture
+def mangrove_shape():
+    data = """
+    {
+   "type":"FeatureCollection",
+   "features":[
+      {
+         "geometry":{
+            "type":"Polygon",
+            "coordinates":[
+               [
+                  [
+                     0,
+                     0
+                  ],
+                  [
+                     0,
+                     100
+                  ],
+                  [
+                     100,
+                     100
+                  ],
+                  [
+                     100,
+                     0
+                  ],
+                  [
+                     0,
+                     0
+                  ]
+               ]
+            ]
+         },
+         "type":"Feature"
+      }
+   ]
+}
+    """
+    data = json.loads(data)["features"][0]
+    tmpdir = tempfile.mkdtemp()
+    filename = os.path.join(tmpdir, "test.json")
+    with fiona.open(
+        filename,
+        "w",
+        driver="GeoJSON",
+        crs=CRS.from_epsg(3577),
+        schema={
+            "geometry": "Polygon",
+        },
+    ) as dst:
+        dst.write(data)
+    return filename
 
 
 @pytest.fixture
@@ -50,11 +112,15 @@ def dataset():
     band_3 = da.from_array(band_3, chunks=(1, -1, -1))
 
     index = [np.datetime64("2000-01-01T00")]
-    coords = {
-        "x": np.linspace(10, 20, band_1.shape[2]),
-        "y": np.linspace(0, 5, band_1.shape[1]),
-        "time": index,
-    }
+
+    affine = Affine.translation(10, 0) * Affine.scale(
+        (20 - 10) / band_1.shape[2], (5 - 0) / band_1.shape[1]
+    )
+    geobox = GeoBox(
+        crs="epsg:3577", affine=affine, width=band_1.shape[2], height=band_1.shape[1]
+    )
+    coords = geobox.xr_coords()
+    coords.update({"time": index})
 
     data_vars = {
         "pv_pc_10": xr.DataArray(
@@ -70,14 +136,14 @@ def dataset():
     return xx
 
 
-def test_native_transform(dataset):
-    mangroves = Mangroves()
+def test_native_transform(dataset, mangrove_shape):
+    mangroves = Mangroves(mangroves_extent=mangrove_shape)
     out_xx = mangroves.native_transform(dataset)
     assert (out_xx == dataset).all()
 
 
-def test_reduce(dataset):
-    mangroves = Mangroves()
+def test_reduce(dataset, mangrove_shape):
+    mangroves = Mangroves(mangroves_extent=mangrove_shape)
     yy = mangroves.reduce(dataset)
     expected_results = dataset.pv_pc_10.copy(True)
     expected_results.data = np.array(


### PR DESCRIPTION
- enforce the use of mangroves extent shapefile
- set `nodata=np.nan` explicitly for wo float band as esri doesn't agree with the default nan on float type.

Note:
nodata issue of gm to be fixed in `odc-algo`. The virtue here is that every band (variable) should carry `nodata` as one of attributes no matter what data type it is, not claiming it's a "better" solution. 