### PR TITLE
Fix gm nodata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -40,7 +40,7 @@ jobs:
           key: wheels-${{ github.sha }}
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -84,7 +84,7 @@ jobs:
       - build-wheels
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Dependencies
         shell: bash
@@ -100,7 +100,7 @@ jobs:
           pip freeze
 
       - name: Get Wheels from Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -14,15 +14,15 @@ jobs:
         && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 
@@ -51,8 +51,8 @@ jobs:
         && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         id: wheels_cache
         with:
           path: ./wheels

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -221,6 +221,7 @@ class StatsGMLS(StatsGM):
             if aux_names is None
             else aux_names
         )
+        print(aux_names)
 
         if bands is None:
             bands = (
@@ -238,7 +239,12 @@ class StatsGMLS(StatsGM):
         # ideally it should be read from product def
         self.nodata_defs = kwargs.pop(
             "nodata_defs",
-            {"count": -999, "sdev": np.nan, "edev": np.nan, "bcdev": np.nan},
+            {
+                aux_names["count"]: -999,
+                aux_names["smad"]: np.nan,
+                aux_names["bcmad"]: np.nan,
+                aux_names["emad"]: np.nan,
+            },
         )
 
         super().__init__(

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -221,7 +221,6 @@ class StatsGMLS(StatsGM):
             if aux_names is None
             else aux_names
         )
-        print(aux_names)
 
         if bands is None:
             bands = (

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -9,7 +9,6 @@ from ._registry import StatsPluginInterface, register
 from odc.algo import enum_to_bool, erase_bad
 from odc.algo import mask_cleanup
 import logging
-import numpy as np
 
 _log = logging.getLogger(__name__)
 
@@ -112,9 +111,9 @@ class StatsGM(StatsPluginInterface):
             "maxiters": 1000,
             "num_threads": 1,
             "scale": scale,
-            "offset": 1 * scale,
+            "offset": -1 * scale,
             "reshape_strategy": "mem",
-            "out_chunks": (1, -1, -1),
+            "out_chunks": (-1, -1, -1),
             "work_chunks": self._work_chunks,
             "compute_count": True,
             "compute_mads": True,
@@ -239,10 +238,9 @@ class StatsGMLS(StatsGM):
         self.nodata_defs = kwargs.pop(
             "nodata_defs",
             {
-                aux_names["count"]: -999,
-                aux_names["smad"]: np.nan,
-                aux_names["bcmad"]: np.nan,
-                aux_names["emad"]: np.nan,
+                aux_names["smad"]: float("nan"),
+                aux_names["bcmad"]: float("nan"),
+                aux_names["emad"]: float("nan"),
             },
         )
 
@@ -267,6 +265,7 @@ class StatsGMLS(StatsGM):
         gm = super().reduce(xx)
         for key, val in self.nodata_defs.items():
             gm[key].attrs["nodata"] = val
+
         return gm
 
 

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -9,6 +9,7 @@ from ._registry import StatsPluginInterface, register
 from odc.algo import enum_to_bool, erase_bad
 from odc.algo import mask_cleanup
 import logging
+import numpy as np
 
 _log = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class StatsGM(StatsPluginInterface):
         **kwargs,
     ):
         aux_names = (
-            dict(smad="smad", emad="emad", bcmad="bcmad", count="count")
+            {"smad": "smad", "emad": "emad", "bcmad": "bcmad", "count": "count"}
             if aux_names is None
             else aux_names
         )
@@ -107,17 +108,17 @@ class StatsGM(StatsPluginInterface):
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         scale = 1 / 10_000
-        cfg = dict(
-            maxiters=1000,
-            num_threads=1,
-            scale=scale,
-            offset=-1 * scale,
-            reshape_strategy="mem",
-            out_chunks=(-1, -1, -1),
-            work_chunks=self._work_chunks,
-            compute_count=True,
-            compute_mads=True,
-        )
+        cfg = {
+            "maxiters": 1000,
+            "num_threads": 1,
+            "scale": scale,
+            "offset": 1 * scale,
+            "reshape_strategy": "mem",
+            "out_chunks": (1, -1, -1),
+            "work_chunks": self._work_chunks,
+            "compute_count": True,
+            "compute_mads": True,
+        }
 
         gm = geomedian_with_mads(xx, **cfg)
         gm = gm.rename(self._renames)
@@ -161,7 +162,7 @@ class StatsGMS2(StatsGM):
         )
 
         aux_names = (
-            dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT")
+            {"smad": "SMAD", "emad": "EMAD", "bcmad": "BCMAD", "count": "COUNT"}
             if aux_names is None
             else aux_names
         )
@@ -216,12 +217,7 @@ class StatsGMLS(StatsGM):
         **kwargs,
     ):
         aux_names = (
-            dict(
-                smad="sdev",
-                emad="edev",
-                bcmad="bcdev",
-                count="count",
-            )
+            {"smad": "sdev", "emad": "edev", "bcmad": "bcdev", "count": "count"}
             if aux_names is None
             else aux_names
         )
@@ -239,6 +235,12 @@ class StatsGMLS(StatsGM):
             if rgb_bands is None:
                 rgb_bands = ("nbart_red", "nbart_green", "nbart_blue")
 
+        # ideally it should be read from product def
+        self.nodata_defs = kwargs.pop(
+            "nodata_defs",
+            {"count": -999, "sdev": np.nan, "edev": np.nan, "bcdev": np.nan},
+        )
+
         super().__init__(
             bands=bands,
             mask_band=mask_band,
@@ -255,6 +257,12 @@ class StatsGMLS(StatsGM):
         return (
             tuple(b for b in self.bands if b != self._contiguity_band) + self.aux_bands
         )
+
+    def reduce(self, xx: xr.Dataset) -> xr.Dataset:
+        gm = super().reduce(xx)
+        for key, val in self.nodata_defs.items():
+            gm[key].attrs["nodata"] = val
+        return gm
 
 
 register("gm-ls", StatsGMLS)

--- a/tests/test_gm_ls.py
+++ b/tests/test_gm_ls.py
@@ -212,4 +212,8 @@ def test_no_data_value(monkeypatch):
 
     bands = [x for x in result.data_vars]
     for x in bands:
-        assert result.nbart_green.attrs.get("nodata", 0) == -999
+        assert result[x].attrs.get("nodata") is not None
+        if result[x].dtype.kind == "f":
+            assert result[x].attrs.get("nodata") != result[x].attrs.get("nodata")
+        else:
+            assert result[x].attrs.get("nodata") == gm_ls.nodata_defs.get(x, -999)

--- a/tests/test_gm_ls.py
+++ b/tests/test_gm_ls.py
@@ -212,8 +212,9 @@ def test_no_data_value(monkeypatch):
 
     bands = [x for x in result.data_vars]
     for x in bands:
-        assert result[x].attrs.get("nodata") is not None
         if result[x].dtype.kind == "f":
             assert result[x].attrs.get("nodata") != result[x].attrs.get("nodata")
         else:
-            assert result[x].attrs.get("nodata") == gm_ls.nodata_defs.get(x, -999)
+            assert (result[x].attrs.get("nodata") == gm_ls.nodata_defs.get(x, -999)) | (
+                result[x].attrs.get("nodata") is None
+            )


### PR DESCRIPTION
I changed my mind on where to fix gm `nodata`  issue, based on the following reasons:
- Both s2 and ls inherit the same plugin and hence same function in computing the gm. They can have their different ways in defining `nodata` for extra bands other than the input bands. 
- The `nodata` is defined  in production definition yaml. All datasets should respect and follow the same definition such that `dc.load` and `rioxarray.open` will result the same `nodata` information. For future improvement ref issue #131 
- The same "hardcode" approach also caused discrepancy between data type of GeoTIFF and one in product def, e.g., `count` being `uint16` in GeoTIFF while `int16` in product def, which results in `int16` in `dc.load` while `uint16` with other tools
- gdal doesn't fully respect default `nodata=nan` for float when generating overviews either. Thus it'd be good that we honour `nodata` definition every level. In this PR, I allowed `nodata` not defined for `count` band because of a) data type discrepancy mentioned above, b) `nodata` not presents in raster hence no trouble atm

I decide to address the coding issues later while keep the path clear for now.