### PR TITLE
Fix fusing nidem

### DIFF
--- a/odc/stats/plugins/lc_veg_class_a1.py
+++ b/odc/stats/plugins/lc_veg_class_a1.py
@@ -51,9 +51,6 @@ class StatsDem(StatsPluginInterface):
 
         return xx
 
-    def fuser(self, xx):
-        return xx
-
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
         if self.measurements != self.input_bands:
             xx = xx.rename(dict(zip(self.input_bands, self.measurements)))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,7 +6,7 @@ future_fstrings
 mock
 moto
 networkx
-numpy
+numpy<2.0
 odc-algo @ git+https://github.com/opendatacube/odc-algo@bb662fe
 odc-cloud>=0.2.5
 odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64


### PR DESCRIPTION
I missed the fact that `nidem` is also in tiles different than current ones and requires to be fused, by default over `nodata`, hence the fix.