### PR TITLE
Woody cover and cultivated model plugins for landcover

### DIFF
--- a/.github/workflows/statistician-image.yml
+++ b/.github/workflows/statistician-image.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           cd docker
-          docker-compose build
+          docker compose build
 
       - name: Run Dockerized Tests for Statistician
         shell: bash

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -16,7 +16,6 @@ dependencies:
   - vim
   - rio-cogeo
   - aiobotocore
-  - awscliv2
   - boto3
   - affine
   - aiohttp

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://packages.dea.ga.gov.au/
 datacube[performance,s3]>=1.8.17
 hdstats==0.1.8.post1
-odc-algo @ git+https://github.com/opendatacube/odc-algo@bb662fe
+odc-algo @ git+https://github.com/opendatacube/odc-algo@40546db
 odc-apps-cloud>=0.2.2
 # For testing
 odc-apps-dc-tools>=0.2.12

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://packages.dea.ga.gov.au/
 datacube[performance,s3]>=1.8.17
 hdstats==0.1.8.post1
-odc-algo @ git+https://github.com/opendatacube/odc-algo@40546db
+odc-algo @ git+https://github.com/opendatacube/odc-algo@adb1856
 odc-apps-cloud>=0.2.2
 # For testing
 odc-apps-dc-tools>=0.2.12
@@ -15,3 +15,4 @@ odc-stats[ows]
 
 # For ML
 tflite-runtime
+tl2cgen

--- a/docker/test_statistician.sh
+++ b/docker/test_statistician.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
-docker-compose up -d
+docker compose up -d
 sleep 5
 
-docker-compose exec -T stats odc-stats --version
+docker compose exec -T stats odc-stats --version
 echo "Indexing some data"
-docker-compose exec -e AWS_DEFAULT_REGION=ap-southeast-2 -T stats ./tests/init_db.sh
+docker compose exec -e AWS_DEFAULT_REGION=ap-southeast-2 -T stats ./tests/init_db.sh
 echo "Data regression test"
-docker-compose exec -T stats  ./tests/integration_test.sh
+docker compose exec -T stats  ./tests/integration_test.sh

--- a/odc/stats/model.py
+++ b/odc/stats/model.py
@@ -440,10 +440,15 @@ class Task:
                     inherit_skip_properties=self.product.inherit_skip_properties,
                 )
 
-                if "eo:platform" in source_datasetdoc.properties:
+                if source_datasetdoc.properties.get("eo:platform") is not None:
                     platforms.append(source_datasetdoc.properties["eo:platform"])
-                if "eo:instrument" in source_datasetdoc.properties:
-                    instruments.append(source_datasetdoc.properties["eo:instrument"])
+                if source_datasetdoc.properties.get("eo:instrument") is not None:
+                    if isinstance(source_datasetdoc.properties["eo:instrument"], list):
+                        instruments += source_datasetdoc.properties["eo:instrument"]
+                    else:
+                        instruments.append(
+                            source_datasetdoc.properties["eo:instrument"]
+                        )
 
         dataset_assembler.platform = ",".join(sorted(set(platforms)))
         dataset_assembler.instrument = "_".join(sorted(set(instruments)))

--- a/odc/stats/plugins/_registry.py
+++ b/odc/stats/plugins/_registry.py
@@ -39,6 +39,7 @@ def import_all():
 
     # TODO: make that more automatic
     modules = [
+        "odc.stats.plugins.lc_treelite_woody",
         "odc.stats.plugins.lc_tf_urban",
         "odc.stats.plugins.lc_veg_class_a1",
         "odc.stats.plugins.lc_fc_wo_a0",

--- a/odc/stats/plugins/_registry.py
+++ b/odc/stats/plugins/_registry.py
@@ -39,6 +39,7 @@ def import_all():
 
     # TODO: make that more automatic
     modules = [
+        "odc.stats.plugins.lc_treelite_cultivated.py",
         "odc.stats.plugins.lc_treelite_woody",
         "odc.stats.plugins.lc_tf_urban",
         "odc.stats.plugins.lc_veg_class_a1",

--- a/odc/stats/plugins/_worker.py
+++ b/odc/stats/plugins/_worker.py
@@ -6,6 +6,7 @@ or to be cached for all plugins
 
 from dask.distributed import WorkerPlugin, get_worker
 import tflite_runtime.interpreter as tflite
+import tl2cgen
 import threading
 import logging
 
@@ -33,3 +34,26 @@ class TensorFlowLiteModelPlugin(WorkerPlugin):
                 thread_id,
             )
         return worker.interpreters[thread_id]
+
+
+class TreeliteModelPlugin(WorkerPlugin):
+    def __init__(self, model_path):
+        self.model_path = model_path
+        self._log = logging.getLogger(__name__)
+
+    def setup(self, worker):
+        worker.plugin_instance = self
+        worker.predictors = {}
+
+    def get_predictor(self):
+        worker = get_worker()
+        thread_id = threading.get_ident()
+        if thread_id not in worker.predictors:
+            predictor = tl2cgen.Predictor(self.model_path)
+            worker.predictors[thread_id] = predictor
+            self._log.info(
+                "Predictor created on worker %s for thread %s",
+                worker.address,
+                thread_id,
+            )
+        return worker.predictors[thread_id]

--- a/odc/stats/plugins/_worker.py
+++ b/odc/stats/plugins/_worker.py
@@ -44,6 +44,7 @@ class TreeliteModelPlugin(WorkerPlugin):
     def setup(self, worker):
         worker.plugin_instance = self
         worker.predictors = {}
+        print(f"registered worker {worker}")
 
     def get_predictor(self):
         worker = get_worker()

--- a/odc/stats/plugins/lc_ml_treelite.py
+++ b/odc/stats/plugins/lc_ml_treelite.py
@@ -1,0 +1,180 @@
+"""
+Plugin of TF urban model in LandCover PipeLine
+"""
+
+from abc import abstractmethod
+from typing import Dict, Sequence, Optional
+
+import os
+import numpy as np
+import numexpr as ne
+import xarray as xr
+import dask.array as da
+from dask.distributed import get_worker
+
+from datacube.model import Dataset
+from datacube.utils.geometry import GeoBox
+from odc.algo._memsink import yxbt_sink
+from odc.algo.io import load_with_native_transform
+
+from odc.stats._algebra import expr_eval
+from ._registry import StatsPluginInterface
+from ._worker import TreeliteModelPlugin
+import tl2cgen
+
+
+def mask_and_predict(block, ptype="categorical", nodata=np.nan, output_dtype="float32"):
+    worker = get_worker()
+    plugin_instance = worker.plugin_instance
+    predictor = plugin_instance.get_predictor()
+
+    block_flat = block.reshape(-1, block.shape[-1])
+    # mask nodata and non-veg
+    mask_flat = ne.evaluate(
+        "where((a==a)&(b>0), 1, 0)",
+        local_dict={"a": block_flat[:, 0], "b": block_flat[:, -1]},
+    ).astype("bool")
+    block_masked = block_flat[mask_flat, :-1]
+
+    prediction = np.full((block.shape[0] * block.shape[1], 1), nodata)
+    if block_masked.shape[0] > 0:
+        dmat = tl2cgen.DMatrix(block_masked)
+        output_data = predictor.predict(dmat).squeeze(axis=1)
+        if ptype == "categorical":
+            prediction[mask_flat] = np.copy(output_data.argmax(axis=-1))
+        else:
+            prediction[mask_flat] = np.copy(output_data)
+
+    return prediction.reshape(*block.shape[:-1]).astype(output_dtype)
+
+
+class StatsMLTree(StatsPluginInterface):
+    NAME = "ga_ls_ml_tree"
+    SHORT_NAME = NAME
+    VERSION = "0.0.1"
+    PRODUCT_FAMILY = "lccs"
+
+    def __init__(
+        self,
+        output_classes: Dict,
+        model_path: str,
+        mask_bands: Optional[Dict] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        if not os.path.exists(model_path):
+            raise FileNotFoundError(f"{self.model_path} not found")
+        self.dask_worker_plugin = TreeliteModelPlugin(model_path)
+        self.output_classes = output_classes
+        self.mask_bands = mask_bands
+
+    def make_mask(self, xx: xr.Dataset, output_dtype="int16") -> xr.Dataset:
+        if self.mask_bands is None:
+            for var in xx.data_vars:
+                xx[var] = xx[var].astype(output_dtype)
+        else:
+            for key, val in self.mask_bands.items():
+                mask = expr_eval(
+                    "where(a==_v, 1, 0)",
+                    {"a": xx[key].data},
+                    name="make_mask",
+                    dtype=output_dtype,
+                    **{"_v": int(val)},
+                )
+                xx[key].data = mask
+        return xx
+
+    def input_data(
+        self, datasets: Sequence[Dataset], geobox: GeoBox, **kwargs
+    ) -> xr.Dataset:
+        # load data in the same time and location but different sensors
+        data_vars = {}
+        dup_dss = {}
+
+        for ds in datasets:
+            if "gm" in ds.type.name:
+                input_bands = self.input_bands[:-1]
+            else:
+                input_bands = self.input_bands[-1:]
+
+            xx = load_with_native_transform(
+                [ds],
+                bands=input_bands,
+                geobox=geobox,
+                native_transform=self.native_transform,
+                basis=self.basis,
+                groupby=None,
+                fuser=None,
+                resampling=self.resampling,
+                chunks={"y": -1, "x": -1},
+                optional_bands=self.optional_bands,
+                **kwargs,
+            )
+            if "gm" in ds.type.name:
+                data_vars[ds.type.name] = xx
+            else:
+                dup_dss[ds.type.name] = self.make_mask(xx).drop_vars(["spec"])
+
+        for ds_type in data_vars:
+            for ds in dup_dss.values():
+                data_vars[ds_type] = data_vars[ds_type].update(ds)
+            input_array = yxbt_sink(
+                data_vars[ds_type], (self.chunks["x"], self.chunks["y"], -1, -1)
+            ).squeeze("spec", drop=True)
+            data_vars[ds_type] = input_array
+
+        coords = dict((dim, input_array.coords[dim]) for dim in input_array.dims)
+        return xr.Dataset(data_vars=data_vars, coords=coords)
+
+    def preprocess_predict_input(self, xx: xr.Dataset):
+        masks = {k: xx.sel(band=k) for k in self.mask_bands}
+        xx = xx.drop_sel(band=self.mask_bands.keys())
+        images = []
+        for var in xx.data_vars:
+            image = xx[var].data
+            nodata = xx[var].attrs.get("nodata", -999)
+            image = expr_eval(
+                "where((a<=nodata), _nan, a)",
+                {
+                    "a": image,
+                },
+                name="convert_dtype",
+                dtype="float32",
+                **{"nodata": nodata, "_nan": np.nan},
+            )
+            images += [image]
+
+        for v in masks.values():
+            dv = None
+            for dv in v.data_vars:
+                if "gm" in dv:
+                    break
+            veg_mask = v[dv].data
+
+        images = [
+            da.concatenate([image, veg_mask[..., np.newaxis]], axis=-1)
+            for image in images
+        ]
+        return images
+
+    @abstractmethod
+    def predict(self, input_array):
+        pass
+
+    @abstractmethod
+    def aggregate_results_from_group(self, predict_output):
+        pass
+
+    def reduce(self, xx: xr.Dataset) -> xr.Dataset:
+        images = self.preprocess_predict_input(xx)
+        res = []
+
+        for image in images:
+            res += [self.predict(image)]
+        res = self.aggregate_results_from_group(res)
+
+        attrs = xx.attrs.copy()
+        dims = list(xx.dims.keys())[:2]
+        data_vars = {"predict_output": xr.DataArray(res, dims=dims, attrs=attrs)}
+        coords = {dim: xx.coords[dim] for dim in dims}
+        return xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs)

--- a/odc/stats/plugins/lc_ml_treelite.py
+++ b/odc/stats/plugins/lc_ml_treelite.py
@@ -150,9 +150,7 @@ class StatsMLTree(StatsPluginInterface):
         pass
 
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
-        print(f"input dataset {xx}")
         images = self.preprocess_predict_input(xx)
-        print(f"after preprocess  {images}")
         res = []
 
         for image in images:

--- a/odc/stats/plugins/lc_ml_treelite.py
+++ b/odc/stats/plugins/lc_ml_treelite.py
@@ -1,5 +1,5 @@
 """
-Plugin of TF urban model in LandCover PipeLine
+Base class for treelite models in LandCover PipeLine
 """
 
 from abc import abstractmethod

--- a/odc/stats/plugins/lc_tf_urban.py
+++ b/odc/stats/plugins/lc_tf_urban.py
@@ -117,7 +117,9 @@ class StatsUrbanClass(StatsPluginInterface):
                 **kwargs,
             )
             input_array = yxbt_sink(
-                xx, (self.crop_size[0], self.crop_size[0], -1, -1)
+                xx,
+                (self.crop_size[0], self.crop_size[0], -1, -1),
+                name=ds.type.name + "_yxbt",
             ).squeeze("spec", drop=True)
             data_vars[ds.type.name] = input_array
 

--- a/odc/stats/plugins/lc_treelite_cultivated.py
+++ b/odc/stats/plugins/lc_treelite_cultivated.py
@@ -1,0 +1,307 @@
+"""
+Plugin of RFclassfication cultivated  model in LandCover PipeLine
+"""
+
+from typing import Tuple
+import numpy as np
+import xarray as xr
+import dask.array as da
+import numexpr as ne
+
+from odc.stats._algebra import expr_eval
+from ._registry import register
+from .lc_ml_treelite import StatsMLTree, mask_and_predict
+
+NODATA = 255
+
+# selected features from sklearn model
+# ['nbart_blue', 'nbart_green', 'nbart_swir_1', 'nbart_swir_2', 'sdev',
+#        'edev', 'bcdev', 'MNDWI', 'BUI', 'BSI', 'TCW', 'NDMI', 'AWEI_sh',
+#        'BAEI', 'NDSI'],
+
+
+# pylint: disable=invalid-name
+def feature_MNDWI(input_block, nbart_green, nbart_swir_1):
+    return ne.evaluate(
+        "(a-b)/(a+b)",
+        local_dict={
+            "a": input_block[..., nbart_green],
+            "b": input_block[..., nbart_swir_1],
+        },
+    ).astype("float32")
+
+
+def feature_BUI(input_block, nbart_swir_1, nbart_nir, nbart_red):
+    return ne.evaluate(
+        "((a-b)/(a+b))-((b-c)/(b+c))",
+        local_dict={
+            "a": input_block[..., nbart_swir_1],
+            "b": input_block[..., nbart_nir],
+            "c": input_block[..., nbart_red],
+        },
+    ).astype("float32")
+
+
+def feature_BSI(input_block, nbart_swir_1, nbart_red, nbart_nir, nbart_blue):
+    return ne.evaluate(
+        "((a+b)-(c+d))/((a+b)+(c+d))",
+        local_dict={
+            "a": input_block[..., nbart_swir_1],
+            "b": input_block[..., nbart_red],
+            "c": input_block[..., nbart_nir],
+            "d": input_block[..., nbart_blue],
+        },
+    ).astype("float32")
+
+
+def feature_TCW(
+    input_block,
+    nbart_blue,
+    nbart_green,
+    nbart_red,
+    nbart_nir,
+    nbart_swir_1,
+    nbart_swir_2,
+):
+    return ne.evaluate(
+        "(0.0315*a+0.2021*b+0.3102*c+0.1594*d+-0.6806*e+-0.6109*f)",
+        local_dict={
+            "a": input_block[..., nbart_blue],
+            "b": input_block[..., nbart_green],
+            "c": input_block[..., nbart_red],
+            "d": input_block[..., nbart_nir],
+            "e": input_block[..., nbart_swir_1],
+            "f": input_block[..., nbart_swir_2],
+        },
+    ).astype("float32")
+
+
+def feature_NDMI(input_block, nbart_nir, nbart_swir_1):
+    return ne.evaluate(
+        "(a-b)/(a+b)",
+        local_dict={
+            "a": input_block[..., nbart_nir],
+            "b": input_block[..., nbart_swir_1],
+        },
+    ).astype("float32")
+
+
+def feature_AWEI_sh(
+    input_block, nbart_blue, nbart_green, nbart_nir, nbart_swir_1, nbart_swir_2
+):
+    return ne.evaluate(
+        "(a+2.5*b-1.5*(c+d)-0.25*e)",
+        local_dict={
+            "a": input_block[..., nbart_blue],
+            "b": input_block[..., nbart_green],
+            "c": input_block[..., nbart_nir],
+            "d": input_block[..., nbart_swir_1],
+            "e": input_block[..., nbart_swir_2],
+        },
+    ).astype("float32")
+
+
+def feature_BAEI(input_block, nbart_red, nbart_green, nbart_swir_1):
+    return ne.evaluate(
+        "(a+0.3)/(b+c)",
+        local_dict={
+            "a": input_block[..., nbart_red],
+            "b": input_block[..., nbart_green],
+            "c": input_block[..., nbart_swir_1],
+        },
+    ).astype("float32")
+
+
+def feature_NDSI(input_block, nbart_green, nbart_swir_1):
+    return ne.evaluate(
+        "(a-b)/(a+b)",
+        local_dict={
+            "a": input_block[..., nbart_green],
+            "b": input_block[..., nbart_swir_1],
+        },
+    ).astype("float32")
+
+
+def generate_features(input_block, bands_indices):
+    feature_input_indices = [
+        [bands_indices[k] for k in ["nbart_green", "nbart_swir_1"]],
+        [bands_indices[k] for k in ["nbart_swir_1", "nbart_nir", "nbart_red"]],
+        [
+            bands_indices[k]
+            for k in ["nbart_swir_1", "nbart_red", "nbart_nir", "nbart_blue"]
+        ],
+        [
+            bands_indices[k]
+            for k in [
+                "nbart_blue",
+                "nbart_green",
+                "nbart_red",
+                "nbart_nir",
+                "nbart_swir_1",
+                "nbart_swir_2",
+            ]
+        ],
+        [bands_indices[k] for k in ["nbart_nir", "nbart_swir_1"]],
+        [
+            bands_indices[k]
+            for k in [
+                "nbart_blue",
+                "nbart_green",
+                "nbart_nir",
+                "nbart_swir_1",
+                "nbart_swir_2",
+            ]
+        ],
+        [bands_indices[k] for k in ["nbart_red", "nbart_green", "nbart_swir_1"]],
+        [bands_indices[k] for k in ["nbart_green", "nbart_swir_1"]],
+    ]
+
+    # normalized against 6 bands
+    norm = np.linalg.norm(
+        input_block[..., : bands_indices["nbart_swir_2"] + 1], axis=-1, keepdims=True
+    )
+    output_block = input_block[..., : bands_indices["nbart_swir_2"] + 1] / np.maximum(
+        norm, 1e-8
+    )  # Avoid division by zero, fine if it's nan
+
+    # reassemble the array
+    output_block = np.concatenate(
+        [output_block, input_block[..., bands_indices["sdev"]][..., np.newaxis]],
+        axis=-1,
+    ).astype("float32")
+    # scale edev \in [0, 1]
+    edev = input_block[..., bands_indices["edev"]] / 1e4
+    output_block = np.concatenate(
+        [output_block, edev[..., np.newaxis]], axis=-1
+    ).astype("float32")
+    output_block = np.concatenate(
+        [output_block, input_block[..., bands_indices["bcdev"]][..., np.newaxis]],
+        axis=-1,
+    ).astype("float32")
+
+    for f, p in zip(
+        [
+            feature_MNDWI,
+            feature_BUI,
+            feature_BSI,
+            feature_TCW,
+            feature_NDMI,
+            feature_AWEI_sh,
+            feature_BAEI,
+            feature_NDSI,
+        ],
+        feature_input_indices,
+    ):
+        ib = f(output_block[..., : bands_indices["nbart_swir_2"] + 1], *p)
+        output_block = np.concatenate([output_block, ib[..., np.newaxis]], axis=-1)
+
+    selected_indices = np.r_[
+        [
+            bands_indices[k]
+            for k in [
+                "nbart_blue",
+                "nbart_green",
+                "nbart_swir_1",
+                "nbart_swir_2",
+                "sdev",
+                "edev",
+                "bcdev",
+            ]
+        ],
+        (bands_indices["bcdev"] + 1) : output_block.shape[-1],
+    ]
+    output_block = np.concatenate(
+        [
+            output_block[..., selected_indices],
+            input_block[..., (bands_indices["bcdev"] + 1) :],
+        ],
+        axis=-1,
+    )
+    return output_block
+
+
+class StatsCultivatedClass(StatsMLTree):
+    NAME = "ga_ls_cultivated"
+    SHORT_NAME = NAME
+    VERSION = "0.0.1"
+    PRODUCT_FAMILY = "lccs"
+
+    @property
+    def measurements(self) -> Tuple[str, ...]:
+        _measurements = ["cultivated_class"]
+        return _measurements
+
+    def predict(self, input_array):
+        bands_indices = dict(zip(self.input_bands, np.arange(len(self.input_bands))))
+        input_features = da.map_blocks(
+            generate_features,
+            input_array,
+            bands_indices,
+            chunks=(
+                self.chunks["x"],
+                self.chunks["y"],
+                15 + len(bands_indices) - bands_indices["bcdev"] - 1,
+            ),
+            dtype="float32",
+            name="generate_features",
+        )
+        cc = da.map_blocks(
+            mask_and_predict,
+            input_features,
+            ptype="categorical",
+            nodata=NODATA,
+            drop_axis=-1,
+            dtype="float32",
+            name="cultivated_predict",
+        )
+        return cc
+
+    def aggregate_results_from_group(self, predict_output):
+        # if there are >= 2 images
+        # any is cultivated -> final class is cultivated
+        # any is valid -> final class is valid
+        # for each pixel
+        m_size = len(predict_output)
+        if m_size > 1:
+            predict_output = da.stack(predict_output).sum(axis=0)
+        else:
+            predict_output = predict_output[0]
+
+        predict_output = expr_eval(
+            "where((a/nodata)>=_l, nodata, a%nodata)",
+            {"a": predict_output},
+            name="mark_nodata",
+            dtype="float32",
+            **{"_l": m_size, "nodata": NODATA},
+        )
+
+        predict_output = expr_eval(
+            "where((a>=_l)&(a<nodata), _u, a)",
+            {"a": predict_output},
+            name="output_classes_natural",
+            dtype="float32",
+            **{"_u": self.output_classes["natural"], "nodata": NODATA, "_l": m_size},
+        )
+
+        predict_output = expr_eval(
+            "where(a<_l, _nu, a)",
+            {"a": predict_output},
+            name="output_classes_cultivated",
+            dtype="uint8",
+            **{"_nu": self.output_classes["cultivated"], "_l": m_size},
+        )
+
+        return predict_output.rechunk(-1, -1)
+
+    def reduce(self, xx: xr.Dataset) -> xr.Dataset:
+        res = super().reduce(xx)
+
+        for var in res.data_vars:
+            attrs = res[var].attrs.copy()
+            attrs["nodata"] = int(NODATA)
+            res[var].attrs = attrs
+            var_rename = {var: "cultivated_class"}
+        return res.rename(var_rename)
+
+
+register("cultivated_class", StatsCultivatedClass)

--- a/odc/stats/plugins/lc_treelite_woody.py
+++ b/odc/stats/plugins/lc_treelite_woody.py
@@ -1,5 +1,5 @@
 """
-Plugin of TF urban model in LandCover PipeLine
+Plugin of RFregressor woody cover model in LandCover PipeLine
 """
 
 from typing import Tuple

--- a/odc/stats/plugins/lc_treelite_woody.py
+++ b/odc/stats/plugins/lc_treelite_woody.py
@@ -1,0 +1,108 @@
+"""
+Plugin of TF urban model in LandCover PipeLine
+"""
+
+from typing import Tuple
+import xarray as xr
+import dask.array as da
+
+from odc.stats._algebra import expr_eval
+from ._registry import register
+from .lc_ml_treelite import StatsMLTree, mask_and_predict
+
+NODATA = 255
+
+
+class StatsWoodyCover(StatsMLTree):
+    NAME = "ga_ls_woody_cover"
+    SHORT_NAME = NAME
+    VERSION = "0.0.1"
+    PRODUCT_FAMILY = "lccs"
+
+    @property
+    def measurements(self) -> Tuple[str, ...]:
+        _measurements = ["woody_cover"]
+        return _measurements
+
+    def predict(self, input_array):
+        wc = da.map_blocks(
+            mask_and_predict,
+            input_array,
+            ptype="regression",
+            nodata=NODATA,
+            drop_axis=-1,
+            dtype="uint8",
+        )
+        return wc
+
+    def aggregate_results_from_group(self, predict_output):
+        # >= 0.2 -> woody < 0.2 -> herbaceous
+        # if there are >= 2 images
+        # any valid -> valid
+        # any herbaceous -> herbaceous
+        woody_covers = predict_output
+        m_size = len(woody_covers)
+        if m_size > 1:
+            woody_covers = da.stack(woody_covers)
+        else:
+            woody_covers = woody_covers[0]
+
+        woody_covers = expr_eval(
+            "where(a<=20, 1, a)",
+            {"a": woody_covers},
+            name="mark_herbaceous",
+            dtype="float32",
+        )
+
+        woody_covers = expr_eval(
+            "where((a>20)&(a<nodata), 0, a)",
+            {"a": woody_covers},
+            name="mark_woody",
+            dtype="float32",
+            **{"nodata": NODATA},
+        )
+
+        if m_size > 1:
+            woody_covers = da.sum(woody_covers, axis=0)
+
+        woody_covers = expr_eval(
+            "where((a/nodata)>=_l, nodata, a%nodata)",
+            {"a": woody_covers},
+            name="summary_over_classes",
+            dtype="uint8",
+            **{
+                "_l": m_size,
+                "nodata": NODATA,
+            },
+        )
+
+        woody_covers = expr_eval(
+            "where((a>0)&(a<nodata), _nw, a)",
+            {"a": woody_covers},
+            name="output_classes_herbaceous",
+            dtype="uint8",
+            **{"nodata": NODATA, "_nw": self.output_classes["herbaceous"]},
+        )
+
+        woody_covers = expr_eval(
+            "where(a<=0, _nw, a)",
+            {"a": woody_covers},
+            name="output_classes_woody",
+            dtype="uint8",
+            **{"_nw": self.output_classes["woody"]},
+        )
+
+        return woody_covers.rechunk(-1, -1)
+
+    def reduce(self, xx: xr.Dataset) -> xr.Dataset:
+        res = super().reduce(xx)
+
+        for var in res.data_vars:
+            attrs = res[var].attrs.copy()
+            attrs["nodata"] = int(NODATA)
+            res[var].attrs = attrs
+            var_rename = {var: "woody_cover"}
+        return res.rename(var_rename)
+
+
+register("woody_cover", StatsWoodyCover)

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     fiona
     rasterio>=1.3.2
     tflite-runtime
+    tl2cgen
 
 [options.entry_points]
 console_scripts =

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,7 +7,7 @@ mock
 moto
 networkx
 numpy<2.0
-odc-algo @ git+https://github.com/opendatacube/odc-algo@bb662fe
+odc-algo @ git+https://github.com/opendatacube/odc-algo@adb1856
 odc-cloud>=0.2.5
 odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
 
@@ -17,6 +17,7 @@ pytest-cov
 pytest-httpserver
 pytest-timeout
 tflite-runtime
+tl2cgen
 
 # patch image
 xarray>=2023.7.0

--- a/tests/test_rf_models.py
+++ b/tests/test_rf_models.py
@@ -1,0 +1,456 @@
+import numpy as np
+import xarray as xr
+import dask.array as da
+from odc.stats.plugins.lc_treelite_cultivated import (
+    StatsCultivatedClass,
+    generate_features,
+)
+from pathlib import Path
+import pytest
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+from datacube.utils.dask import start_local_dask
+
+client = start_local_dask(n_workers=1, threads_per_worker=2)
+
+project_root = Path(__file__).parents[1]
+data_dir = f"{project_root}/tests/data/"
+
+
+@pytest.fixture(scope="module")
+def cultivated_model_path():
+    s3_bucket = "dea-public-data-dev"
+    s3_key = "lccs_models/cultivated/treelite/cultivated_treelite.so"
+    local_path = "/tmp/model.so"
+
+    # Download the model from S3
+    s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+    s3.download_file(s3_bucket, s3_key, local_path)
+
+    yield local_path
+
+
+@pytest.fixture(scope="module")
+def woody_model_path():
+    s3_bucket = "dea-public-data-dev"
+    s3_key = "lccs_models/wcf/treelite/woody_treelite.so"
+    local_path = "/tmp/model.so"
+
+    # Download the model from S3
+    s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
+    s3.download_file(s3_bucket, s3_key, local_path)
+
+    yield local_path
+
+
+@pytest.fixture(scope="module")
+def cultivated_classes():
+    return {"cultivated": 111, "natural": 112}
+
+
+@pytest.fixture(scope="module")
+def mask_bands():
+    return {"classes_l3_l4": 110}
+
+
+@pytest.fixture(scope="module")
+def input_arrays():
+    data = np.array(
+        [
+            [
+                [
+                    3.32e02,
+                    1.05e02,
+                    1.92e02,
+                    8.7e01,
+                    7.4e01,
+                    6.4e01,
+                    1.4010848e-02,
+                    1.7472041e02,
+                    2.2962935e-01,
+                ],
+                [
+                    3.37e02,
+                    1.11e02,
+                    1.96e02,
+                    9.7e01,
+                    8.2e01,
+                    7.1e01,
+                    1.9971754e-02,
+                    1.9717915e02,
+                    2.7176377e-01,
+                ],
+            ],
+            [
+                [
+                    3.33e02,
+                    1.06e02,
+                    1.93e02,
+                    8.8e01,
+                    7.6e01,
+                    6.5e01,
+                    1.2302631e-02,
+                    1.8164543e02,
+                    2.3910587e-01,
+                ],
+                [
+                    3.4e02,
+                    1.1e02,
+                    1.99e02,
+                    8.9e01,
+                    7.7e01,
+                    6.6e01,
+                    1.3445648e-02,
+                    1.6739888e02,
+                    2.6565611e-01,
+                ],
+            ],
+        ],
+        dtype="float32",
+    )
+
+    coords = {
+        "x": np.linspace(10, 20, data.shape[1]),
+        "y": np.linspace(0, 5, data.shape[0]),
+        "bands": [
+            "nbart_blue",
+            "nbart_red",
+            "nbart_green",
+            "nbart_nir",
+            "nbart_swir_1",
+            "nbart_swir_2",
+            "sdev",
+            "edev",
+            "bcdev",
+        ],
+    }
+
+    return xr.DataArray(
+        data, dims=("y", "x", "bands"), coords=coords, attrs={"nodata": -999}
+    )
+
+
+@pytest.fixture(scope="module")
+def input_datasets():
+    img_1 = np.array(
+        [
+            [
+                [
+                    3.32e02,
+                    1.05e02,
+                    1.92e02,
+                    8.7e01,
+                    7.4e01,
+                    6.4e01,
+                    1.4010848e-02,
+                    1.7472041e02,
+                    2.2962935e-01,
+                ],
+                [
+                    3.37e02,
+                    1.11e02,
+                    1.96e02,
+                    9.7e01,
+                    8.2e01,
+                    7.1e01,
+                    1.9971754e-02,
+                    1.9717915e02,
+                    2.7176377e-01,
+                ],
+            ],
+            [
+                [
+                    3.33e02,
+                    1.06e02,
+                    1.93e02,
+                    8.8e01,
+                    7.6e01,
+                    6.5e01,
+                    1.2302631e-02,
+                    1.8164543e02,
+                    2.3910587e-011,
+                ],
+                [-999, -999, -999, -999, -999, -999, np.nan, np.nan, np.nan],
+            ],
+        ],
+        dtype="float32",
+    )
+
+    img_1 = da.from_array(img_1, chunks=(-1, -1, -1))
+
+    img_2 = np.array(
+        [
+            [
+                [
+                    2.74e02,
+                    1.72e02,
+                    1.07e02,
+                    1.08e02,
+                    7.0e01,
+                    7.0e01,
+                    1.9283541e-02,
+                    1.4928413e02,
+                    1.9332452e-01,
+                ],
+                [
+                    2.74e02,
+                    1.67e02,
+                    9.6e01,
+                    1.02e02,
+                    6.6e01,
+                    6.8e01,
+                    1.2028454e-02,
+                    1.3096216e02,
+                    1.9045363e-01,
+                ],
+            ],
+            [
+                [
+                    2.92e02,
+                    1.84e02,
+                    1.17e02,
+                    1.11e02,
+                    8.6e01,
+                    7.0e01,
+                    1.5552766e-02,
+                    1.4088402e02,
+                    1.9069320e-01,
+                ],
+                [
+                    2.91e02,
+                    1.8e02,
+                    1.14e02,
+                    1.1e02,
+                    7.2e01,
+                    5.7e01,
+                    1.1063328e-02,
+                    1.4271451e02,
+                    1.7535155e-01,
+                ],
+            ],
+        ],
+        dtype="float32",
+    )
+
+    img_2 = da.from_array(img_2, chunks=(-1, -1, -1))
+
+    img_3 = np.array([[110, 213], [110, 110]], dtype="float32")
+
+    img_3 = da.from_array(img_3, chunks=(-1, -1))
+
+    coords = {
+        "x": np.linspace(10, 20, img_1.shape[1]),
+        "y": np.linspace(0, 5, img_1.shape[0]),
+        "bands": [
+            "nbart_blue",
+            "nbart_red",
+            "nbart_green",
+            "nbart_nir",
+            "nbart_swir_1",
+            "nbart_swir_2",
+            "sdev",
+            "edev",
+            "bcdev",
+        ],
+    }
+
+    data_vars = {
+        "ga_ls7": xr.DataArray(img_1, dims=("y", "x", "bands"), attrs={"nodata": -999}),
+        "ga_ls8": xr.DataArray(img_2, dims=("y", "x", "bands"), attrs={"nodata": -999}),
+        "classes_l3_l4": xr.DataArray(img_3, dims=("y", "x")),
+    }
+    xx = xr.Dataset(data_vars=data_vars, coords=coords)
+    return xx
+
+
+@pytest.fixture(scope="module")
+def cultivated_results():
+    res = [
+        da.array([[1.0, 255.0], [0.0, 1.0]], dtype="uint8"),
+        da.array([[0.0, 1], [0.0, 1.0]], dtype="uint8"),
+    ]
+    return res
+
+
+@pytest.fixture(scope="module")
+def cultivated_input_bands():
+    return [
+        "nbart_blue",
+        "nbart_green",
+        "nbart_red",
+        "nbart_nir",
+        "nbart_swir_1",
+        "nbart_swir_2",
+        "sdev",
+        "edev",
+        "bcdev",
+        "classes_l3_l4",
+    ]
+
+
+def test_genrate_features(cultivated_input_bands, input_arrays):
+    bands_indices = dict(
+        zip(cultivated_input_bands, np.arange(len(cultivated_input_bands)))
+    )
+    res = generate_features(input_arrays.data, bands_indices)
+    expected_res = np.array(
+        [
+            [
+                [
+                    0.7930565,
+                    0.25081605,
+                    0.1767656,
+                    0.15287836,
+                    0.01401085,
+                    0.01747204,
+                    0.22962935,
+                    0.17318432,
+                    0.29559875,
+                    -0.22335766,
+                    0.03736609,
+                    0.08074532,
+                    0.8050001,
+                    1.774246,
+                    0.17318432,
+                ],
+                [
+                    0.7824946,
+                    0.2577356,
+                    0.19039929,
+                    0.16485791,
+                    0.01997175,
+                    0.01971791,
+                    0.27176377,
+                    0.15025905,
+                    0.2540851,
+                    -0.21910109,
+                    0.02351315,
+                    0.08379885,
+                    0.7621776,
+                    1.6849853,
+                    0.15025905,
+                ],
+            ],
+            [
+                [
+                    0.79124624,
+                    0.2518682,
+                    0.18058473,
+                    0.15444747,
+                    0.01230263,
+                    0.01816454,
+                    0.23910587,
+                    0.16483518,
+                    0.3004947,
+                    -0.22028984,
+                    0.03415381,
+                    0.07317075,
+                    0.7977806,
+                    1.7541567,
+                    0.16483518,
+                ],
+                [
+                    0.789403,
+                    0.25539508,
+                    0.17877656,
+                    0.15323706,
+                    0.01344565,
+                    0.01673989,
+                    0.2656561,
+                    0.17647058,
+                    0.3096553,
+                    -0.21702127,
+                    0.03745439,
+                    0.07228915,
+                    0.81145984,
+                    1.7551421,
+                    0.17647058,
+                ],
+            ],
+        ],
+        dtype="float32",
+    )
+
+    assert np.allclose(res, expected_res, rtol=1e-6, atol=1e-8)
+
+
+def test_preprocess_predict_intput(
+    cultivated_input_bands,
+    cultivated_model_path,
+    mask_bands,
+    cultivated_classes,
+    input_datasets,
+):
+    cultivated = StatsCultivatedClass(
+        cultivated_classes,
+        cultivated_model_path,
+        mask_bands,
+        input_bands=cultivated_input_bands,
+    )
+    res = cultivated.preprocess_predict_input(input_datasets)
+    for r in res:
+        assert (r[..., -1] == np.array([[1, 0], [1, 1]])).all()
+
+
+def test_cultivated_predict(
+    cultivated_input_bands,
+    cultivated_model_path,
+    mask_bands,
+    cultivated_classes,
+    input_datasets,
+):
+    cultivated = StatsCultivatedClass(
+        cultivated_classes,
+        cultivated_model_path,
+        mask_bands,
+        input_bands=cultivated_input_bands,
+    )
+    client.register_plugin(cultivated.dask_worker_plugin)
+    imgs = cultivated.preprocess_predict_input(input_datasets)
+    res = [cultivated.predict(img).compute() for img in imgs]
+    assert (
+        np.array(res)
+        == np.array([[[1.0, 255.0], [1.0, 255.0]], [[1.0, 255.0], [1.0, 1.0]]])
+    ).all()
+
+
+def test_cultivated_aggregate_results(
+    cultivated_input_bands,
+    cultivated_model_path,
+    mask_bands,
+    cultivated_classes,
+    cultivated_results,
+):
+    cultivated = StatsCultivatedClass(
+        cultivated_classes,
+        cultivated_model_path,
+        mask_bands,
+        input_bands=cultivated_input_bands,
+    )
+    res = cultivated.aggregate_results_from_group([cultivated_results[0]])
+    assert (res.compute() == np.array([[112, 255], [111, 112]], dtype="uint8")).all()
+    res = cultivated.aggregate_results_from_group(cultivated_results)
+    assert (res.compute() == np.array([[111, 112], [111, 112]], dtype="uint8")).all()
+
+
+def test_cultivated_reduce(
+    cultivated_input_bands,
+    cultivated_model_path,
+    mask_bands,
+    cultivated_classes,
+    input_datasets,
+):
+    cultivated = StatsCultivatedClass(
+        cultivated_classes,
+        cultivated_model_path,
+        mask_bands,
+        input_bands=cultivated_input_bands,
+    )
+    client.register_plugin(cultivated.dask_worker_plugin)
+    res = cultivated.reduce(input_datasets)
+    assert res["cultivated_class"].attrs["nodata"] == 255
+    assert (
+        res["cultivated_class"].data.compute()
+        == np.array([[112, 255], [112, 112]], dtype="uint8")
+    ).all()


### PR DESCRIPTION
Major changes:
- added dask worker plugin for `treelite` predictor for multithreading safety
- added a plugin class for all models of `treelite` as they share common routines
- added plugins for woody cover and cultivated model
- added tests for above changes

cultivated model diagram:
![image](https://github.com/user-attachments/assets/75a2051c-1c6e-4e59-b172-388a62322141)

woody cover diagram
![image](https://github.com/user-attachments/assets/1860cb40-e736-4960-97ba-2103cb2000b6)

Minor changes:
- updated `odc-algo` head which concerns safe casting (ref: https://github.com/opendatacube/odc-algo/pull/13) and memory sanity (ref: https://github.com/opendatacube/odc-algo/pull/12)
- `docker-compose` to `docker compose`