### PR TITLE
Fix bugs in cultivated and woody cover plugins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,9 @@ ENV GDAL_DRIVER_PATH=/env/lib/gdalplugins \
     GDAL_DATA=/env/share/gdal \
     PATH=/env/bin:$PATH
 
+# here is very hacky fix for the threading issue
+# MUST follow up with package owner and further address the issue accordingly
+
 RUN wget -O /env/lib/python3.10/site-packages/numexpr/necompiler.py https://raw.githubusercontent.com/emmaai/numexpr/master/numexpr/necompiler.py
 
 WORKDIR /tmp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ ENV GDAL_DRIVER_PATH=/env/lib/gdalplugins \
 # here is very hacky fix for the threading issue
 # MUST follow up with package owner and further address the issue accordingly
 
-RUN wget -O /env/lib/python3.10/site-packages/numexpr/necompiler.py https://raw.githubusercontent.com/emmaai/numexpr/master/numexpr/necompiler.py
+RUN wget -q -O /env/lib/python3.10/site-packages/numexpr/necompiler.py https://raw.githubusercontent.com/emmaai/numexpr/master/numexpr/necompiler.py
 
 WORKDIR /tmp
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,8 @@ ENV GDAL_DRIVER_PATH=/env/lib/gdalplugins \
     GDAL_DATA=/env/share/gdal \
     PATH=/env/bin:$PATH
 
+RUN wget -O /env/lib/python3.10/site-packages/numexpr/necompiler.py https://raw.githubusercontent.com/emmaai/numexpr/master/numexpr/necompiler.py
+
 WORKDIR /tmp
 
 RUN odc-stats --version 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ odc-dscache>=0.2.3
 odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
 
 # odc-stac is in PyPI
-odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@bad6a6c
+odc-stats[ows]
 
 # For ML
 tflite-runtime

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ odc-dscache>=0.2.3
 odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
 
 # odc-stac is in PyPI
-odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@cb28745
+odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@8dfd442
 
 # For ML
 tflite-runtime

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ odc-dscache>=0.2.3
 odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
 
 # odc-stac is in PyPI
-odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@f3f3b91
+odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@cb28745
 
 # For ML
 tflite-runtime

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ odc-dscache>=0.2.3
 odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
 
 # odc-stac is in PyPI
-odc-stats[ows]
+odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@f3f3b91
 
 # For ML
 tflite-runtime

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -11,7 +11,7 @@ odc-dscache>=0.2.3
 odc-stac @ git+https://github.com/opendatacube/odc-stac@69bdf64
 
 # odc-stac is in PyPI
-odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@8dfd442
+odc-stats[ows] @ git+https://github.com/opendatacube/odc-stats@bad6a6c
 
 # For ML
 tflite-runtime

--- a/odc/stats/plugins/lc_ml_treelite.py
+++ b/odc/stats/plugins/lc_ml_treelite.py
@@ -44,6 +44,8 @@ def mask_and_predict(
     if block_masked.shape[0] > 0:
         dmat = tl2cgen.DMatrix(block_masked)
         output_data = predictor.predict(dmat).squeeze(axis=1)
+        # round the number to float32 resolution
+        output_data = np.round(output_data, 6)
         if ptype == "categorical":
             prediction[mask_flat] = output_data.argmax(axis=-1)[..., np.newaxis]
         else:

--- a/odc/stats/plugins/lc_treelite_woody.py
+++ b/odc/stats/plugins/lc_treelite_woody.py
@@ -63,7 +63,7 @@ class StatsWoodyCover(StatsMLTree):
         )
 
         if m_size > 1:
-            predict_output = predict_output.sum(axis=0).astype("int")
+            predict_output = predict_output.sum(axis=0)
 
         predict_output = expr_eval(
             "where((a/nodata)>=_l, nodata, a%nodata)",

--- a/odc/stats/plugins/lc_treelite_woody.py
+++ b/odc/stats/plugins/lc_treelite_woody.py
@@ -69,7 +69,7 @@ class StatsWoodyCover(StatsMLTree):
             "where((a/nodata)>=_l, nodata, a%nodata)",
             {"a": predict_output},
             name="summary_over_classes",
-            dtype="uint8",
+            dtype="float32",
             **{
                 "_l": m_size,
                 "nodata": NODATA,
@@ -80,7 +80,7 @@ class StatsWoodyCover(StatsMLTree):
             "where((a>0)&(a<nodata), _nw, a)",
             {"a": predict_output},
             name="output_classes_herbaceous",
-            dtype="uint8",
+            dtype="float32",
             **{"nodata": NODATA, "_nw": self.output_classes["herbaceous"]},
         )
 

--- a/tests/test_rf_models.py
+++ b/tests/test_rf_models.py
@@ -492,6 +492,10 @@ def test_cultivated_reduce(
         == np.array([[112, 255], [112, 112]], dtype="uint8")
     ).all()
 
+    with pytest.raises(SystemExit) as excinfo:
+        cultivated.reduce(input_datasets.drop("classes_l3_l4"))
+    assert excinfo.value.code == 0
+
 
 def test_woody_aggregate_results(
     woody_input_bands,


### PR DESCRIPTION
Addressed issues:
- results from cultivated and woody cover run with pipeline showed discrepancy on tiles randomly from run to run, after investigations and experiments, confirmed that it's caused by `numexpr` package, the relevant issue was raised https://github.com/pydata/numexpr/issues/494
- input bands missing due to unavailable inputs from even upper streams, hence allow the graceful exist.

Note:
I have put into a hot (means very hacky) fix for the `numexpr` package, which is remarked in the docker file. We must follow up on this issue and address in the future.