### PR TITLE
update numexpr with fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,6 +10,11 @@ RUN micromamba create  -y -p /env -f /conf/env.yaml && \
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
 ARG UPDATE_VERSION=1
 COPY requirements.txt /conf/
+# required to build numexpr
+# or any --no-binary
+ENV CC=/env/bin/x86_64-conda_cos6-linux-gnu-gcc \
+    CXX=/env/bin/x86_64-conda_cos6-linux-gnu-g++ \
+    LDSHARED="/env/bin/x86_64-conda_cos6-linux-gnu-gcc -pthread -shared -B /env/compiler_compat -L/env/lib -Wl,-rpath=/env/lib -Wl,--no-as-needed"
 RUN micromamba run -p /env pip install --no-cache-dir \
     --no-build-isolation -r /conf/requirements.txt
 
@@ -21,11 +26,6 @@ ENV GDAL_DRIVER_PATH=/env/lib/gdalplugins \
     PROJ_LIB=/env/share/proj \
     GDAL_DATA=/env/share/gdal \
     PATH=/env/bin:$PATH
-
-# here is very hacky fix for the threading issue
-# MUST follow up with package owner and further address the issue accordingly
-
-RUN wget -q -O /env/lib/python3.10/site-packages/numexpr/necompiler.py https://raw.githubusercontent.com/emmaai/numexpr/master/numexpr/necompiler.py
 
 WORKDIR /tmp
 

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -7,6 +7,9 @@ dependencies:
   - gdal>=3.8
   - proj
   - rasterio>=1.3.2
+  - gcc_linux-64
+  - gxx_linux-64
+  - binutils_linux-64
   - libpq
   - git
   - wget
@@ -76,7 +79,6 @@ dependencies:
   - munch
   - netCDF4
   - networkx
-  - numexpr
 # for the sake of geomedian address this later
   - numpy<2.0
   - ordered-set

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,6 +2,7 @@
 --extra-index-url https://packages.dea.ga.gov.au/
 datacube[performance,s3]>=1.8.17
 hdstats==0.1.8.post1
+numexpr @ git+https://github.com/pydata/numexpr@a99412e
 odc-algo @ git+https://github.com/opendatacube/odc-algo@adb1856
 odc-apps-cloud>=0.2.2
 # For testing


### PR DESCRIPTION
Remove the hacky bit in last commit, as I have fixed and closed the issue in the package repo (ref:https://github.com/pydata/numexpr/issues/494). No new release published yet hence settled for compiling and installing from repo head (at least more ideal than the hack).