### PR TITLE
Fix the issue of input data nodata changing by the odc loading

### DIFF
--- a/odc/stats/plugins/_base.py
+++ b/odc/stats/plugins/_base.py
@@ -53,7 +53,7 @@ class StatsPluginInterface(ABC):
                 xx[var].attrs.get("nodata") is None
                 and np.dtype(xx[var].dtype).kind == "f"
             ):
-                xx[var].attrs["nodata"] = np.nan
+                xx[var].attrs["nodata"] = xx[var].dtype.type(None)
         return xx
 
     def fuser(self, xx: xr.Dataset) -> xr.Dataset:

--- a/odc/stats/plugins/_base.py
+++ b/odc/stats/plugins/_base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Mapping, Optional, Sequence, Tuple
 
 import xarray as xr
+import numpy as np
 from datacube.model import Dataset
 from datacube.utils.geometry import GeoBox
 from odc.algo import to_rgba
@@ -47,6 +48,12 @@ class StatsPluginInterface(ABC):
         pass
 
     def native_transform(self, xx: xr.Dataset) -> xr.Dataset:
+        for var in xx.data_vars:
+            if (
+                xx[var].attrs.get("nodata") is None
+                and np.dtype(xx[var].dtype).kind == "f"
+            ):
+                xx[var].attrs["nodata"] = np.nan
         return xx
 
     def fuser(self, xx: xr.Dataset) -> xr.Dataset:

--- a/odc/stats/plugins/lc_level3.py
+++ b/odc/stats/plugins/lc_level3.py
@@ -21,16 +21,22 @@ class StatsLccsLevel3(StatsPluginInterface):
         _measurements = ["level3_class"]
         return _measurements
 
+    def fuser(self, xx: xr.Dataset) -> xr.Dataset:
+        return xx
+
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
 
         # Cultivated pipeline applies a mask which feeds only terrestrial veg (110) to the model
-        # Just exclude no data (255) and apply the cultivated results
+        # Just exclude no data (255 or nan) and apply the cultivated results
+        # 255: load with product definition; nan: load without
+        # hence accormmodate both
+
         res = expr_eval(
-            "where(a<nodata, a, b)",
+            "where(((a==a)&(nodata!=nodata))|((a<nodata)&(nodata==nodata)), a, b)",
             {"a": xx.cultivated_class.data, "b": xx.classes_l3_l4.data},
             name="mask_cultivated",
             dtype="float32",
-            **{"nodata": NODATA},
+            **{"nodata": xx.cultivated_class.attrs.get("nodata")},
         )
 
         # Mask urban results with bare sfc (210)
@@ -42,8 +48,20 @@ class StatsLccsLevel3(StatsPluginInterface):
                 "b": xx.urban_classes.data,
             },
             name="mark_urban",
-            dtype="uint8",
+            dtype="float32",
             **{"_u": 210},
+        )
+
+        # Mark nodata to 255 in case any nan
+
+        res = expr_eval(
+            "where(a==a, a, nodata)",
+            {
+                "a": res,
+            },
+            name="mark_nodata",
+            dtype="uint8",
+            **{"nodata": NODATA},
         )
 
         attrs = xx.attrs.copy()

--- a/odc/stats/plugins/lc_level3.py
+++ b/odc/stats/plugins/lc_level3.py
@@ -32,7 +32,7 @@ class StatsLccsLevel3(StatsPluginInterface):
         # hence accormmodate both
 
         res = expr_eval(
-            "where(((a==a)&(nodata!=nodata))|((a<nodata)&(nodata==nodata)), a, b)",
+            "where((a!=a)|(a>=nodata), b, a)",
             {"a": xx.cultivated_class.data, "b": xx.classes_l3_l4.data},
             name="mask_cultivated",
             dtype="float32",

--- a/odc/stats/plugins/lc_veg_class_a1.py
+++ b/odc/stats/plugins/lc_veg_class_a1.py
@@ -200,15 +200,14 @@ class StatsVegClassL1(StatsPluginInterface):
 
         # Mask nans with NODATA
         l3_mask = expr_eval(
-            "where((a!=a)|((b>=_n)&(_n==_n))|(b!=b), nodata, e)",
+            "where((a!=a), nodata, e)",
             {
                 "a": si5,
-                "b": xx.veg_frequency.data,
                 "e": l3_mask,
             },
             name="mark_nodata",
             dtype="uint8",
-            **{"_n": xx.veg_frequency.attrs["nodata"], "nodata": NODATA},
+            **{"nodata": NODATA},
         )
 
         # Now add the water frequency

--- a/odc/stats/plugins/lc_veg_class_a1.py
+++ b/odc/stats/plugins/lc_veg_class_a1.py
@@ -174,7 +174,7 @@ class StatsVegClassL1(StatsPluginInterface):
                     # aquatic_veg: (mangroves > 0) & (mangroves != nodata)
                     # mangroves.nodata = 255 or nan
                     l3_mask = expr_eval(
-                        "where(((a>0)&(a<nodata)&(nodata==nodata))|((a>0)&(nodata!=nodata)), m, b)",
+                        "where((a>0)&((a<nodata)|(nodata!=nodata)), m, b)",
                         {"a": xx[b].data, "b": l3_mask},
                         name="mark_mangroves",
                         dtype="uint8",


### PR DESCRIPTION
As the title, ref https://github.com/opendatacube/datacube-core/issues/1646

- carry the nodata following the same convention in `datacube`
- minor refactor of code always reading `nodata` from dataset attributes

Note that it's not a fundamental solution, as the issue raised in `datacube`, ideally the loading process should inform any change, as `None` can be understood and dealt with so many ways. Currently `datacube` rely on the assumption that people agree with one, which might not always be true.