### PR TITLE
Apply urban mask on landcover level3

### DIFF
--- a/odc/stats/plugins/_utils.py
+++ b/odc/stats/plugins/_utils.py
@@ -1,24 +1,42 @@
 import dask
-import fiona
-from rasterio import features
+from osgeo import gdal, ogr, osr
 
 
-def rasterize_vector_mask(shape_file, transform, dst_shape, threshold=None):
-    with fiona.open(shape_file) as source_ds:
-        geoms = [s["geometry"] for s in source_ds]
+def rasterize_vector_mask(
+    shape_file, transform, dst_shape, filter_expression=None, threshold=None
+):
+    source_ds = ogr.Open(shape_file)
+    source_layer = source_ds.GetLayer()
 
-    mask = features.rasterize(
-        geoms,
-        transform=transform,
-        out_shape=dst_shape[1:],
-        all_touched=False,
-        fill=0,
-        default_value=1,
-        dtype="uint8",
+    if filter_expression is not None:
+        source_layer.SetAttributeFilter(filter_expression)
+
+    yt, xt = dst_shape[1:]
+    no_data = 0
+    albers = osr.SpatialReference()
+    albers.ImportFromEPSG(3577)
+
+    geotransform = (
+        transform.c,
+        transform.a,
+        transform.b,
+        transform.f,
+        transform.d,
+        transform.e,
     )
+    target_ds = gdal.GetDriverByName("MEM").Create("", xt, yt, gdal.GDT_Byte)
+    target_ds.SetGeoTransform(geotransform)
+    target_ds.SetProjection(albers.ExportToWkt())
+    mask = target_ds.GetRasterBand(1)
+    mask.SetNoDataValue(no_data)
+    gdal.RasterizeLayer(target_ds, [1], source_layer, burn_values=[1])
 
+    mask = mask.ReadAsArray()
+
+    # used by landcover level3 urban
     # if valid area >= threshold
     # then the whole tile is valid
+
     if threshold is not None:
         if mask.sum() > mask.size * threshold:
             return dask.array.ones(dst_shape, name=False)

--- a/odc/stats/plugins/_utils.py
+++ b/odc/stats/plugins/_utils.py
@@ -1,0 +1,26 @@
+import dask
+import fiona
+from rasterio import features
+
+
+def rasterize_vector_mask(shape_file, transform, dst_shape, threshold=None):
+    with fiona.open(shape_file) as source_ds:
+        geoms = [s["geometry"] for s in source_ds]
+
+    mask = features.rasterize(
+        geoms,
+        transform=transform,
+        out_shape=dst_shape[1:],
+        all_touched=False,
+        fill=0,
+        default_value=1,
+        dtype="uint8",
+    )
+
+    # if valid area >= threshold
+    # then the whole tile is valid
+    if threshold is not None:
+        if mask.sum() > mask.size * threshold:
+            return dask.array.ones(dst_shape, name=False)
+
+    return dask.array.from_array(mask.reshape(dst_shape), name=False)

--- a/odc/stats/plugins/l34_utils/lc_level3.py
+++ b/odc/stats/plugins/l34_utils/lc_level3.py
@@ -21,18 +21,29 @@ def lc_level3(xx: xr.Dataset, urban_mask):
     )
 
     # Mask urban results with bare sfc (210)
-    # and urban mask
 
     res = expr_eval(
-        "where((a==_u)&(c>0), b, a)",
+        "where((a==_u), b, a)",
         {
             "a": res,
             "b": xx.artificial_surface.data,
-            "c": urban_mask,
         },
         name="mark_urban",
         dtype="float32",
         **{"_u": 210},
+    )
+
+    # Enforce non-urban mask area to be n/artificial (216)
+
+    res = expr_eval(
+        "where((b<=0)&(a==_u), _nu, a)",
+        {
+            "a": res,
+            "b": urban_mask,
+        },
+        name="mask_non_urban",
+        dtype="float32",
+        **{"_u": 215, "_nu": 216},
     )
 
     # Mark nodata to 255 in case any nan

--- a/odc/stats/plugins/l34_utils/lc_level3.py
+++ b/odc/stats/plugins/l34_utils/lc_level3.py
@@ -5,7 +5,7 @@ from odc.stats._algebra import expr_eval
 NODATA = 255
 
 
-def lc_level3(xx: xr.Dataset):
+def lc_level3(xx: xr.Dataset, urban_mask):
 
     # Cultivated pipeline applies a mask which feeds only terrestrial veg (110) to the model
     # Just exclude no data (255 or nan) and apply the cultivated results
@@ -23,10 +23,11 @@ def lc_level3(xx: xr.Dataset):
     # Mask urban results with bare sfc (210)
 
     res = expr_eval(
-        "where(a==_u, b, a)",
+        "where((a==_u)&(c>0), b, a)",
         {
             "a": res,
-            "b": xx.urban_classes.data,
+            "b": xx.artificial_surface.data,
+            "c": urban_mask,
         },
         name="mark_urban",
         dtype="float32",

--- a/odc/stats/plugins/l34_utils/lc_level3.py
+++ b/odc/stats/plugins/l34_utils/lc_level3.py
@@ -21,6 +21,7 @@ def lc_level3(xx: xr.Dataset, urban_mask):
     )
 
     # Mask urban results with bare sfc (210)
+    # and urban mask
 
     res = expr_eval(
         "where((a==_u)&(c>0), b, a)",

--- a/odc/stats/plugins/lc_level34.py
+++ b/odc/stats/plugins/lc_level34.py
@@ -123,4 +123,4 @@ class StatsLccsLevel4(StatsPluginInterface):
         return leve34
 
 
-register("lc_l3_l4", StatsLccsLevel4)
+register("lccs_level34", StatsLccsLevel4)

--- a/odc/stats/plugins/lc_level34.py
+++ b/odc/stats/plugins/lc_level34.py
@@ -6,8 +6,10 @@ from typing import Optional, List
 
 import numpy as np
 import xarray as xr
+import os
 
 from ._registry import StatsPluginInterface, register
+from ._utils import rasterize_vector_mask
 
 from .l34_utils import (
     l4_water_persistence,
@@ -33,12 +35,20 @@ class StatsLccsLevel4(StatsPluginInterface):
 
     def __init__(
         self,
+        urban_mask: str = None,
+        mask_threshold: Optional[float] = None,
         veg_threshold: Optional[List] = None,
         bare_threshold: Optional[List] = None,
         watper_threshold: Optional[List] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
+        if urban_mask is None:
+            raise ValueError("Missing urban mask shapefile")
+        if not os.path.exists(urban_mask):
+            raise FileNotFoundError(f"{urban_mask} not found")
+        self.urban_mask = urban_mask
+        self.mask_threshold = mask_threshold
 
         self.veg_threshold = (
             veg_threshold if veg_threshold is not None else [1, 4, 15, 40, 65, 100]
@@ -51,6 +61,7 @@ class StatsLccsLevel4(StatsPluginInterface):
     def fuser(self, xx):
         return xx
 
+    # pylint: disable=too-many-locals
     def reduce(self, xx: xr.Dataset) -> xr.Dataset:
 
         # Water persistence
@@ -62,7 +73,13 @@ class StatsLccsLevel4(StatsPluginInterface):
         l4 = l4_water.water_classification(xx, water_persistence)
 
         # Generate Level3 classes
-        level3 = lc_level3.lc_level3(xx)
+        urban_mask = rasterize_vector_mask(
+            self.urban_mask,
+            xx.geobox.transform,
+            xx.artificial_surface.shape,
+            threshold=self.mask_threshold,
+        )
+        level3 = lc_level3.lc_level3(xx, urban_mask)
 
         # Vegetation cover
         veg_cover = l4_veg_cover.canopyco_veg_con(xx, self.veg_threshold)

--- a/odc/stats/plugins/lc_level34.py
+++ b/odc/stats/plugins/lc_level34.py
@@ -36,6 +36,7 @@ class StatsLccsLevel4(StatsPluginInterface):
     def __init__(
         self,
         urban_mask: str = None,
+        filter_expression: str = None,
         mask_threshold: Optional[float] = None,
         veg_threshold: Optional[List] = None,
         bare_threshold: Optional[List] = None,
@@ -47,7 +48,12 @@ class StatsLccsLevel4(StatsPluginInterface):
             raise ValueError("Missing urban mask shapefile")
         if not os.path.exists(urban_mask):
             raise FileNotFoundError(f"{urban_mask} not found")
+
+        if filter_expression is None:
+            raise ValueError("Missing urban mask filter")
+
         self.urban_mask = urban_mask
+        self.filter_expression = filter_expression
         self.mask_threshold = mask_threshold
 
         self.veg_threshold = (
@@ -77,8 +83,10 @@ class StatsLccsLevel4(StatsPluginInterface):
             self.urban_mask,
             xx.geobox.transform,
             xx.artificial_surface.shape,
+            filter_expression=self.filter_expression,
             threshold=self.mask_threshold,
         )
+
         level3 = lc_level3.lc_level3(xx, urban_mask)
 
         # Vegetation cover

--- a/odc/stats/plugins/lc_level34.py
+++ b/odc/stats/plugins/lc_level34.py
@@ -6,10 +6,10 @@ from typing import Optional, List
 
 import numpy as np
 import xarray as xr
-import os
 
 from ._registry import StatsPluginInterface, register
 from ._utils import rasterize_vector_mask
+from osgeo import gdal
 
 from .l34_utils import (
     l4_water_persistence,
@@ -46,7 +46,9 @@ class StatsLccsLevel4(StatsPluginInterface):
         super().__init__(**kwargs)
         if urban_mask is None:
             raise ValueError("Missing urban mask shapefile")
-        if not os.path.exists(urban_mask):
+
+        file_metadata = gdal.VSIStatL(urban_mask)
+        if file_metadata is None:
             raise FileNotFoundError(f"{urban_mask} not found")
 
         if filter_expression is None:

--- a/odc/stats/plugins/mangroves.py
+++ b/odc/stats/plugins/mangroves.py
@@ -9,10 +9,9 @@ import xarray as xr
 import dask
 import os
 from odc.algo import keep_good_only, erase_bad
-import fiona
-from rasterio import features
 
 from ._registry import StatsPluginInterface, register
+from ._utils import rasterize_vector_mask
 
 NODATA = 255
 
@@ -45,22 +44,6 @@ class Mangroves(StatsPluginInterface):
         _measurements = ["canopy_cover_class"]
         return _measurements
 
-    def rasterize_mangroves_extent(self, shape_file, transform, dst_shape):
-        with fiona.open(shape_file) as source_ds:
-            geoms = [s["geometry"] for s in source_ds]
-
-        mangrove_extent = features.rasterize(
-            geoms,
-            transform=transform,
-            out_shape=dst_shape[1:],
-            all_touched=False,
-            fill=0,
-            default_value=1,
-            dtype="uint8",
-        )
-
-        return dask.array.from_array(mangrove_extent.reshape(dst_shape), name=False)
-
     def fuser(self, xx):
         """
         no fuse required for mangroves since group by none
@@ -73,7 +56,7 @@ class Mangroves(StatsPluginInterface):
         mangroves computation here
         it is not a 'reduce' though
         """
-        extent_mask = self.rasterize_mangroves_extent(
+        extent_mask = rasterize_vector_mask(
             self.mangroves_extent, xx.geobox.transform, xx.pv_pc_10.shape
         )
         good_data = extent_mask == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,3 +215,13 @@ def urban_shape():
     ) as dst:
         dst.write(data)
     return filename
+
+
+@pytest.fixture()
+def veg_threshold():
+    return [1, 4, 15, 40, 65, 100]
+
+
+@pytest.fixture()
+def watper_threshold():
+    return [1, 4, 7, 10]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,12 @@ from mock import MagicMock
 import boto3
 from moto import mock_aws
 from odc.stats.plugins import register
+import json
+import tempfile
+import os
+import fiona
+from fiona.crs import CRS
+
 from . import DummyPlugin
 
 TEST_DIR = pathlib.Path(__file__).parent.absolute()
@@ -148,3 +154,64 @@ def usgs_ls8_sr_definition():
         ],
     }
     return definition
+
+
+@pytest.fixture
+def urban_shape():
+    data = """
+    {
+       "type":"FeatureCollection",
+       "features":[
+          {
+             "geometry":{
+                "type":"Polygon",
+                "coordinates":[
+                   [
+                      [
+                         0,
+                         0
+                      ],
+                      [
+                         0,
+                         100
+                      ],
+                      [
+                         100,
+                         100
+                      ],
+                      [
+                         100,
+                         0
+                      ],
+                      [
+                         0,
+                         0
+                      ]
+                   ]
+                ]
+             },
+             "type":"Feature",
+             "properties":
+                {
+                    "name": "mock",
+                    "value": 10
+                }
+          }
+       ]
+    }
+    """
+    data = json.loads(data)["features"][0]
+    tmpdir = tempfile.mkdtemp()
+    filename = os.path.join(tmpdir, "test.json")
+    with fiona.open(
+        filename,
+        "w",
+        driver="GeoJSON",
+        crs=CRS.from_epsg(3577),
+        schema={
+            "geometry": "Polygon",
+            "properties": {"name": "str", "value": "int"},
+        },
+    ) as dst:
+        dst.write(data)
+    return filename

--- a/tests/test_lc_l34.py
+++ b/tests/test_lc_l34.py
@@ -172,7 +172,7 @@ def image_groups():
     return xx
 
 
-def test_l4_classes(image_groups):
+def test_l4_classes(image_groups, urban_shape):
     expected_l3 = [[216, 216, 215], [216, 216, 216], [220, 215, 215], [220, 220, 220]]
 
     expected_l4 = [[95, 97, 93], [97, 96, 96], [100, 93, 93], [101, 101, 101]]

--- a/tests/test_lc_l34.py
+++ b/tests/test_lc_l34.py
@@ -3,11 +3,6 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 import dask.array as da
-import json
-import tempfile
-import os
-import fiona
-from fiona.crs import CRS
 from datacube.utils.geometry import GeoBox
 from affine import Affine
 
@@ -16,61 +11,6 @@ import pytest
 
 
 NODATA = 255
-
-
-@pytest.fixture(scope="module")
-def urban_shape():
-    data = """
-    {
-   "type":"FeatureCollection",
-   "features":[
-      {
-         "geometry":{
-            "type":"Polygon",
-            "coordinates":[
-               [
-                  [
-                     0,
-                     0
-                  ],
-                  [
-                     0,
-                     100
-                  ],
-                  [
-                     100,
-                     100
-                  ],
-                  [
-                     100,
-                     0
-                  ],
-                  [
-                     0,
-                     0
-                  ]
-               ]
-            ]
-         },
-         "type":"Feature"
-      }
-   ]
-}
-    """
-    data = json.loads(data)["features"][0]
-    tmpdir = tempfile.mkdtemp()
-    filename = os.path.join(tmpdir, "test.json")
-    with fiona.open(
-        filename,
-        "w",
-        driver="GeoJSON",
-        crs=CRS.from_epsg(3577),
-        schema={
-            "geometry": "Polygon",
-        },
-    ) as dst:
-        dst.write(data)
-    return filename
 
 
 @pytest.fixture(scope="module")
@@ -237,7 +177,10 @@ def test_l4_classes(image_groups):
 
     expected_l4 = [[95, 97, 93], [97, 96, 96], [100, 93, 93], [101, 101, 101]]
     stats_l4 = StatsLccsLevel4(
-        measurements=["level3", "level4"], urban_mask=urban_shape, mask_threshold=0.3
+        measurements=["level3", "level4"],
+        urban_mask=urban_shape,
+        filter_expression="mock > 9",
+        mask_threshold=0.3,
     )
     ds = stats_l4.reduce(image_groups)
 

--- a/tests/test_lc_l34.py
+++ b/tests/test_lc_l34.py
@@ -3,11 +3,74 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 import dask.array as da
+import json
+import tempfile
+import os
+import fiona
+from fiona.crs import CRS
+from datacube.utils.geometry import GeoBox
+from affine import Affine
+
 
 import pytest
 
 
 NODATA = 255
+
+
+@pytest.fixture(scope="module")
+def urban_shape():
+    data = """
+    {
+   "type":"FeatureCollection",
+   "features":[
+      {
+         "geometry":{
+            "type":"Polygon",
+            "coordinates":[
+               [
+                  [
+                     0,
+                     0
+                  ],
+                  [
+                     0,
+                     100
+                  ],
+                  [
+                     100,
+                     100
+                  ],
+                  [
+                     100,
+                     0
+                  ],
+                  [
+                     0,
+                     0
+                  ]
+               ]
+            ]
+         },
+         "type":"Feature"
+      }
+   ]
+}
+    """
+    data = json.loads(data)["features"][0]
+    tmpdir = tempfile.mkdtemp()
+    filename = os.path.join(tmpdir, "test.json")
+    with fiona.open(
+        filename,
+        "w",
+        driver="GeoJSON",
+        crs=CRS.from_epsg(3577),
+        schema={
+            "geometry": "Polygon",
+        },
+    ) as dst:
+        dst.write(data)
+    return filename
 
 
 @pytest.fixture(scope="module")
@@ -112,10 +175,14 @@ def image_groups():
         (np.datetime64("2000-01-01T00"), np.datetime64("2000-01-01")),
     ]
     index = pd.MultiIndex.from_tuples(tuples, names=["time", "solar_day"])
-    coords = {
-        "x": np.linspace(10, 20, l34.shape[2]),
-        "y": np.linspace(0, 5, l34.shape[1]),
-    }
+
+    affine = Affine.translation(10, 0) * Affine.scale(
+        (20 - 10) / l34.shape[2], (5 - 0) / l34.shape[1]
+    )
+    geobox = GeoBox(
+        crs="epsg:3577", affine=affine, width=l34.shape[2], height=l34.shape[1]
+    )
+    coords = geobox.xr_coords()
 
     data_vars = {
         "level_3_4": xr.DataArray(
@@ -123,7 +190,7 @@ def image_groups():
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
         ),
-        "urban_classes": xr.DataArray(
+        "artificial_surface": xr.DataArray(
             da.from_array(urban, chunks=(1, -1, -1)),
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
@@ -169,7 +236,9 @@ def test_l4_classes(image_groups):
     expected_l3 = [[216, 216, 215], [216, 216, 216], [220, 215, 215], [220, 220, 220]]
 
     expected_l4 = [[95, 97, 93], [97, 96, 96], [100, 93, 93], [101, 101, 101]]
-    stats_l4 = StatsLccsLevel4(measurements=["level3", "level4"])
+    stats_l4 = StatsLccsLevel4(
+        measurements=["level3", "level4"], urban_mask=urban_shape, mask_threshold=0.3
+    )
     ds = stats_l4.reduce(image_groups)
 
     assert (ds.level3.compute() == expected_l3).all()

--- a/tests/test_lc_l4_ctv.py
+++ b/tests/test_lc_l4_ctv.py
@@ -2,7 +2,6 @@ import numpy as np
 import xarray as xr
 import dask.array as da
 
-from odc.stats.plugins.lc_level34 import StatsLccsLevel4
 from odc.stats.plugins.l34_utils import (
     l4_cultivated,
     lc_level3,
@@ -31,7 +30,7 @@ def image_groups(l34, urban, cultivated, woody, pv_pc_50):
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
         ),
-        "urban_classes": xr.DataArray(
+        "artificial_surface": xr.DataArray(
             da.from_array(urban, chunks=(1, -1, -1)),
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
@@ -57,7 +56,7 @@ def image_groups(l34, urban, cultivated, woody, pv_pc_50):
     return xx
 
 
-def test_ctv_classes_woody():
+def test_ctv_classes_woody(veg_threshold):
 
     expected_cultivated_classes = [
         [13, 10, 9],
@@ -126,17 +125,17 @@ def test_ctv_classes_woody():
         dtype="uint8",
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
 
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
     l4_ctv = l4_cultivated.lc_l4_cultivated(xx.level_3_4, level3, xx.woody, veg_cover)
 
     assert (l4_ctv.compute() == expected_cultivated_classes).all()
 
 
-def test_ctv_classes_herbaceous():
+def test_ctv_classes_herbaceous(veg_threshold):
 
     expected_cultivated_classes = [
         [18, 15, 14],
@@ -205,16 +204,16 @@ def test_ctv_classes_herbaceous():
         dtype="uint8",
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
 
     l4_ctv = l4_cultivated.lc_l4_cultivated(xx.level_3_4, level3, xx.woody, veg_cover)
     assert (l4_ctv.compute() == expected_cultivated_classes).all()
 
 
-def test_ctv_classes_woody_herbaceous():
+def test_ctv_classes_woody_herbaceous(veg_threshold):
 
     expected_cultivated_classes = [
         [13, 10, 9],
@@ -283,17 +282,17 @@ def test_ctv_classes_woody_herbaceous():
         dtype="int",
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
 
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
     l4_ctv = l4_cultivated.lc_l4_cultivated(xx.level_3_4, level3, xx.woody, veg_cover)
 
     assert (l4_ctv.compute() == expected_cultivated_classes).all()
 
 
-def test_ctv_classes_no_vegcover():
+def test_ctv_classes_no_vegcover(veg_threshold):
 
     expected_cultivated_classes = [
         [2, 2, 2],
@@ -363,10 +362,11 @@ def test_ctv_classes_no_vegcover():
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
+
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
     l4_ctv = l4_cultivated.lc_l4_cultivated(xx.level_3_4, level3, xx.woody, veg_cover)
 
     assert (l4_ctv.compute() == expected_cultivated_classes).all()

--- a/tests/test_lc_l4_natural_surface.py
+++ b/tests/test_lc_l4_natural_surface.py
@@ -40,7 +40,7 @@ def image_groups(
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
         ),
-        "urban_classes": xr.DataArray(
+        "artificial_surface": xr.DataArray(
             da.from_array(urban, chunks=(1, -1, -1)),
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
@@ -81,7 +81,7 @@ def image_groups(
     return xx
 
 
-def test_ns():
+def test_ns(veg_threshold):
     expected_l4_srf_classes = [
         [95, 97, 93],
         [97, 96, 96],
@@ -188,9 +188,9 @@ def test_ns():
         l34, urban, woody, bs_pc_50, pv_pc_50, cultivated, water_frequency, water_season
     )
 
-    level3 = lc_level3.lc_level3(xx)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
 
-    veg_threshold = [1, 4, 15, 40, 65, 100]
     veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
 
     # Apply cultivated to match the code in Level4 processing

--- a/tests/test_lc_l4_nav.py
+++ b/tests/test_lc_l4_nav.py
@@ -6,7 +6,6 @@ import numpy as np
 import xarray as xr
 import dask.array as da
 
-from odc.stats.plugins.lc_level34 import StatsLccsLevel4
 from odc.stats.plugins.l34_utils import (
     l4_cultivated,
     lc_level3,
@@ -39,7 +38,7 @@ def image_groups(
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
         ),
-        "urban_classes": xr.DataArray(
+        "artificial_surface": xr.DataArray(
             da.from_array(urban, chunks=(1, -1, -1)),
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
@@ -75,7 +74,7 @@ def image_groups(
     return xx
 
 
-def test_ntv_classes_woody_herbaceous():
+def test_ntv_classes_woody_herbaceous(veg_threshold):
     expected_l4_ntv_classes = [[56, 56, 56], [57, 57, 57], [56, 56, 56], [57, 57, 57]]
 
     l34 = np.array(
@@ -165,10 +164,10 @@ def test_ntv_classes_woody_herbaceous():
     xx = image_groups(
         l34, urban, cultivated, woody, pv_pc_50, water_frequency, water_season
     )
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
 
     # Apply cultivated to match the code in Level4 processing
     l4_ctv = l4_cultivated.lc_l4_cultivated(xx.level_3_4, level3, xx.woody, veg_cover)
@@ -181,7 +180,7 @@ def test_ntv_classes_woody_herbaceous():
     assert (l4_ctv_ntv_nav.compute() == expected_l4_ntv_classes).all()
 
 
-def test_ntv_herbaceous_seasonal_water_veg_cover():
+def test_ntv_herbaceous_seasonal_water_veg_cover(veg_threshold):
     expected_l4_ntv_classes = [
         [91, 83, 79],
         [80, 82, 83],
@@ -275,10 +274,10 @@ def test_ntv_herbaceous_seasonal_water_veg_cover():
     xx = image_groups(
         l34, urban, cultivated, woody, pv_pc_50, water_frequency, water_season
     )
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
 
     # Apply cultivated to match the code in Level4 processing
     l4_ctv = l4_cultivated.lc_l4_cultivated(xx.level_3_4, level3, xx.woody, veg_cover)
@@ -291,7 +290,7 @@ def test_ntv_herbaceous_seasonal_water_veg_cover():
     assert (l4_ctv_ntv_nav.compute() == expected_l4_ntv_classes).all()
 
 
-def test_ntv_woody_seasonal_water_veg_cover():
+def test_ntv_woody_seasonal_water_veg_cover(veg_threshold):
     expected_l4_ntv_classes = [
         [76, 68, 64],
         [65, 67, 68],
@@ -385,10 +384,10 @@ def test_ntv_woody_seasonal_water_veg_cover():
     xx = image_groups(
         l34, urban, cultivated, woody, pv_pc_50, water_frequency, water_season
     )
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
 
     # Apply cultivated to match the code in Level4 processing
     l4_ctv = l4_cultivated.lc_l4_cultivated(xx.level_3_4, level3, xx.woody, veg_cover)

--- a/tests/test_lc_l4_ntv.py
+++ b/tests/test_lc_l4_ntv.py
@@ -6,7 +6,6 @@ import numpy as np
 import xarray as xr
 import dask.array as da
 
-from odc.stats.plugins.lc_level34 import StatsLccsLevel4
 from odc.stats.plugins.l34_utils import (
     lc_level3,
     l4_veg_cover,
@@ -35,7 +34,7 @@ def image_groups(l34, urban, cultivated, woody, pv_pc_50):
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
         ),
-        "urban_classes": xr.DataArray(
+        "artificial_surface": xr.DataArray(
             da.from_array(urban, chunks=(1, -1, -1)),
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
@@ -61,7 +60,7 @@ def image_groups(l34, urban, cultivated, woody, pv_pc_50):
     return xx
 
 
-def test_ntv_classes_herbaceous():
+def test_ntv_classes_herbaceous(veg_threshold):
 
     expected_natural_terrestrial_veg_classes = [
         [36, 33, 32],
@@ -130,16 +129,16 @@ def test_ntv_classes_herbaceous():
         dtype="uint8",
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
 
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
     l4_ntv = l4_natural_veg.lc_l4_natural_veg(xx.level_3_4, level3, xx.woody, veg_cover)
     assert (l4_ntv.compute() == expected_natural_terrestrial_veg_classes).all()
 
 
-def test_ntv_classes_woody():
+def test_ntv_classes_woody(veg_threshold):
 
     expected_natural_terrestrial_veg_classes = [
         [31, 28, 27],
@@ -208,16 +207,16 @@ def test_ntv_classes_woody():
         dtype="uint8",
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
 
     l4_ntv = l4_natural_veg.lc_l4_natural_veg(xx.level_3_4, level3, xx.woody, veg_cover)
     assert (l4_ntv.compute() == expected_natural_terrestrial_veg_classes).all()
 
 
-def test_ntv_classes_no_veg():
+def test_ntv_classes_no_veg(veg_threshold):
 
     expected_natural_terrestrial_veg_classes = [
         [20, 20, 20],
@@ -286,16 +285,16 @@ def test_ntv_classes_no_veg():
         dtype="uint8",
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
 
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
     l4_ntv = l4_natural_veg.lc_l4_natural_veg(xx.level_3_4, level3, xx.woody, veg_cover)
     assert (l4_ntv.compute() == expected_natural_terrestrial_veg_classes).all()
 
 
-def test_ntv_classes_no_lifeform():
+def test_ntv_classes_no_lifeform(veg_threshold):
 
     expected_natural_terrestrial_veg_classes = [
         [26, 23, 22],
@@ -364,10 +363,10 @@ def test_ntv_classes_no_lifeform():
         dtype="uint8",
     )
     xx = image_groups(l34, urban, cultivated, woody, pv_pc_50)
+    mock_urban_mask = da.ones(xx.artificial_surface.shape)
 
-    stats_l4 = StatsLccsLevel4()
-    level3 = lc_level3.lc_level3(xx)
+    level3 = lc_level3.lc_level3(xx, mock_urban_mask)
 
-    veg_cover = l4_veg_cover.canopyco_veg_con(xx, stats_l4.veg_threshold)
+    veg_cover = l4_veg_cover.canopyco_veg_con(xx, veg_threshold)
     l4_ntv = l4_natural_veg.lc_l4_natural_veg(xx.level_3_4, level3, xx.woody, veg_cover)
     assert (l4_ntv.compute() == expected_natural_terrestrial_veg_classes).all()

--- a/tests/test_lc_l4_water.py
+++ b/tests/test_lc_l4_water.py
@@ -6,7 +6,6 @@ import numpy as np
 import xarray as xr
 import dask.array as da
 
-from odc.stats.plugins.lc_level34 import StatsLccsLevel4
 from odc.stats.plugins.l34_utils import (
     l4_water_persistence,
     l4_water,
@@ -35,7 +34,7 @@ def image_groups(l34, urban, cultivated, woody, bs_pc_50, pv_pc_50, water_freque
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
         ),
-        "urban_classes": xr.DataArray(
+        "artificial_surface": xr.DataArray(
             da.from_array(urban, chunks=(1, -1, -1)),
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
@@ -71,7 +70,7 @@ def image_groups(l34, urban, cultivated, woody, bs_pc_50, pv_pc_50, water_freque
     return xx
 
 
-def test_water_classes():
+def test_water_classes(watper_threshold):
     expected_water_classes = [
         [[104, 104, 104], [103, 103, 103], [102, 102, 101], [99, 101, 101]],
     ]
@@ -161,19 +160,15 @@ def test_water_classes():
         l34, urban, cultivated, woody, bs_pc_50, pv_pc_50, water_frequency
     )
 
-    stats_l4 = StatsLccsLevel4()
-
     # Water persistence
-    water_persistence = l4_water_persistence.water_persistence(
-        xx, stats_l4.watper_threshold
-    )
+    water_persistence = l4_water_persistence.water_persistence(xx, watper_threshold)
 
     l4_water_classes = l4_water.water_classification(xx, water_persistence)
 
     assert (l4_water_classes.compute() == expected_water_classes).all()
 
 
-def test_water_intertidal():
+def test_water_intertidal(watper_threshold):
 
     expected_water_classes = [
         [100, 100, 100],
@@ -267,12 +262,8 @@ def test_water_intertidal():
         l34, urban, cultivated, woody, bs_pc_50, pv_pc_50, water_frequency
     )
 
-    stats_l4 = StatsLccsLevel4()
-
     # Water persistence
-    water_persistence = l4_water_persistence.water_persistence(
-        xx, stats_l4.watper_threshold
-    )
+    water_persistence = l4_water_persistence.water_persistence(xx, watper_threshold)
 
     l4_water_classes = l4_water.water_classification(xx, water_persistence)
 

--- a/tests/test_lc_level3.py
+++ b/tests/test_lc_level3.py
@@ -4,6 +4,10 @@ import xarray as xr
 import dask.array as da
 
 from odc.stats.plugins.l34_utils import lc_level3
+from odc.stats.plugins._utils import rasterize_vector_mask
+from datacube.utils.geometry import GeoBox
+from affine import Affine
+
 import pytest
 
 NODATA = 255
@@ -58,10 +62,14 @@ def image_groups():
         (np.datetime64("2000-01-01T00"), np.datetime64("2000-01-01")),
     ]
     index = pd.MultiIndex.from_tuples(tuples, names=["time", "solar_day"])
-    coords = {
-        "x": np.linspace(10, 20, l34.shape[2]),
-        "y": np.linspace(0, 5, l34.shape[1]),
-    }
+
+    affine = Affine.translation(10, 0) * Affine.scale(
+        (20 - 10) / l34.shape[2], (5 - 0) / l34.shape[1]
+    )
+    geobox = GeoBox(
+        crs="epsg:3577", affine=affine, width=l34.shape[2], height=l34.shape[1]
+    )
+    coords = geobox.xr_coords()
 
     data_vars = {
         "level_3_4": xr.DataArray(
@@ -69,7 +77,7 @@ def image_groups():
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
         ),
-        "urban_classes": xr.DataArray(
+        "artificial_surface": xr.DataArray(
             da.from_array(urban, chunks=(1, -1, -1)),
             dims=("spec", "y", "x"),
             attrs={"nodata": 255},
@@ -85,7 +93,15 @@ def image_groups():
     return xx
 
 
-def test_l3_classes(image_groups):
+def test_l3_classes(image_groups, urban_shape):
+    filter_expression = "mock > 9"
+    urban_mask = rasterize_vector_mask(
+        urban_shape,
+        image_groups.geobox.transform,
+        image_groups.artificial_surface.shape,
+        filter_expression=filter_expression,
+        threshold=0.3,
+    )
 
-    level3_classes = lc_level3.lc_level3(image_groups)
+    level3_classes = lc_level3.lc_level3(image_groups, urban_mask)
     assert (level3_classes == expected_l3_classes).all()


### PR DESCRIPTION
Changes:
- used gdal instead of shapely for better efficiency
- shared the same mask function between mangroves and urban
- fixed and deconvoluted landcover l34 tests