### PR TITLE
Update dependencies

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - libgdal
   - gdal>=3.8
   - proj
-  - rasterio>=1.3.2
+  - rasterio>=1.4.3
   - gcc_linux-64
   - gxx_linux-64
   - binutils_linux-64

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -125,6 +125,7 @@ dependencies:
   - tblib
   - text-unidecode
   - tifffile
+  - timezonefinder
   - tomli
   - toolz
   - tornado


### PR DESCRIPTION
As the title, it's to burn the cache in ecr, and avoid `datacube-ows` bringing its own dependency.