### PR TITLE
Cross-repo refactor of stac/eo3 code

### DIFF
--- a/odc/stats/_stac_fetch.py
+++ b/odc/stats/_stac_fetch.py
@@ -1,7 +1,7 @@
 import json
 
 from odc.aio import S3Fetcher, s3_find_glob
-from odc.stac import stac2ds
+from datacube.metadata import stac2ds
 from pystac.item import Item
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,14 +22,13 @@ install_requires =
     botocore
     click>=8.0.0
     dask
-    datacube>=1.9.5
+    datacube>=1.9.6
     distributed>=2025.4
     numpy
     odc-cloud[ASYNC]>=0.2.5
     odc_algo>=1.0.1
     odc_dscache>=1.9
     odc_io
-    odc_stac>=0.4.0
     odc-geo>=0.5.0rc1
     pandas
     pystac>=1.1.0


### PR DESCRIPTION
ODC-Stats arm of the big eo3/STAC refactor.

- Remove explicit dependency on odc-stac
- pin to core >=1.9.6
- import stac2ds from its new home in core instead of from odc-stac

**See Also**
- https://github.com/opendatacube/datacube-core/pull/2027
- https://github.com/opendatacube/odc-stac/issues/219