### PR TITLE
CI: use OIDC for CodeCov

### DIFF
--- a/.github/workflows/create-new-tag.yml
+++ b/.github/workflows/create-new-tag.yml
@@ -12,7 +12,7 @@ jobs:
   bump_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 2
 
@@ -23,7 +23,7 @@ jobs:
 
       - name: Patch Package Versions when code change.
         id: patch-version
-        uses: anothrNick/github-tag-action@v1
+        uses: anothrNick/github-tag-action@4ed44965e0db8dab2b466a16da04aec3cc312fd8 # 1.75.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BUMP: patch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,8 @@ jobs:
 
   test-wheels:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     container:
       image: ghcr.io/opendatacube/odc-stats:latest
       credentials:
@@ -149,6 +151,6 @@ jobs:
 
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           fail_ci_if_error: false
           verbose: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,18 +29,18 @@ jobs:
         && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: wheels_cache
         with:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.10"
 
@@ -82,7 +82,7 @@ jobs:
       - build-wheels
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Install Dependencies
         shell: bash
@@ -98,7 +98,7 @@ jobs:
           pip freeze
 
       - name: Get Wheels from Cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: wheels_cache
         with:
           path: ./wheels
@@ -147,7 +147,7 @@ jobs:
         if: |
           github.repository == 'opendatacube/odc-stats'
 
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
   test-wheels:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository }}:latest
+      image: ghcr.io/opendatacube/odc-stats:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -14,15 +14,15 @@ jobs:
         && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: wheels_cache
         with:
           path: ./wheels
           key: wheels-${{ github.sha }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
           python-version: "3.10"
 
@@ -51,8 +51,8 @@ jobs:
         && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: wheels_cache
         with:
           path: ./wheels

--- a/.github/workflows/statistician-dive.yml
+++ b/.github/workflows/statistician-dive.yml
@@ -26,10 +26,10 @@ jobs:
     name: Analyze image efficiency
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: lint
-        uses: luke142367/Docker-Lint-Action@v1.1.1
+        uses: luke142367/Docker-Lint-Action@5c4c86226f39785a66827bbc2e322600c9afa3a9 # v1.1.1
         with:
           target: Dockerfile
         env:
@@ -47,7 +47,7 @@ jobs:
           wagoodman/dive:v0.12.0  --ci-config /.dive-ci ${ORG}/${IMAGE}:_build
 
       - name: Docker image size check
-        uses: wemake-services/docker-image-size-limit@2.0.0
+        uses: wemake-services/docker-image-size-limit@f5970eb0c2180ac296475bfd22c5a58955370051 # 2.2.0
         with:
           image: ${{ env.ORG }}/${{ env.IMAGE}}:_build
           size: "3 GiB"

--- a/.github/workflows/statistician-image.yml
+++ b/.github/workflows/statistician-image.yml
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: lint Dockerfile
-        uses: hadolint/hadolint-action@v2.0.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: Dockerfile
           ignore: DL3008,DL3002,DL3013,DL3021,DL3059,SC2102
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build a new docker image with tag
         id: tag-image
@@ -78,18 +78,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
         with:
           role-to-assume: arn:aws:iam::538673716275:role/github-actions-role
           aws-region: ap-southeast-2
 
       - name: Push image to ECR
-        uses: whoan/docker-build-with-cache-action@master
+        uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
         with:
           context: .
           registry: 538673716275.dkr.ecr.ap-southeast-2.amazonaws.com
@@ -105,12 +105,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Push image to ghcr
-        uses: whoan/docker-build-with-cache-action@master
+        uses: whoan/docker-build-with-cache-action@d8d3ad518e7ac382b880720d0751815e656fe032 # v8.1.0
         with:
           context: .
           registry: ghcr.io

--- a/.github/workflows/statistician-image.yml
+++ b/.github/workflows/statistician-image.yml
@@ -2,6 +2,7 @@ name: Statistician Test and Push
 
 env:
   IMAGE_NAME: opendatacube/datacube-statistician
+  DOCKER_IMAGE: opendatacube/odc-stats
 
 on:
   pull_request:
@@ -116,6 +117,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          image_name: ${{ github.repository }}
+          image_name: ${{ env.DOCKER_IMAGE }}
           image_tag: latest,${{ needs.set_tags.outputs.image_tag }}
           build_extra_args: '{"--build-arg": "UPDATE_VERSION=${{ needs.set_tags.outputs.image_tag }}"}'


### PR DESCRIPTION
This uses a short-lived token
which is better for security.

Also throw in a commit which pins
the CI action versions.