### PR TITLE
With Geomad and LESS ram for integration tests

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,11 +1,10 @@
 
---extra-index-url https://packages.dea.ga.gov.au/
 datacube-ows>=1.9
 datacube[performance,s3]>=1.9.5
 eodatasets3>1.9
-hdstats==0.1.8.post1
+geomad
 numexpr>=2.11
-odc-algo>=1.0.1
+odc-algo>=1.1.0
 odc-apps-cloud>=0.2.2
 # For testing
 odc-apps-dc-tools>=0.2.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,8 @@ install_requires =
     distributed>=2025.4
     numpy
     odc-cloud[ASYNC]>=0.2.5
-    odc_algo>=1.0.1
+    odc_algo>=1.1.0
+    geomad
     odc_dscache>=1.9
     odc_io
     odc-geo>=0.5.0rc1

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -3,6 +3,7 @@
 set -e
 set -o pipefail
 
+
 odc-stats --version
 # echo "Checking save tasks"
 # odc-stats save-tasks --grid africa-20 --year 2019 --overwrite --input-products s2_l2a test-run.db
@@ -11,37 +12,37 @@ odc-stats --version
 
 echo "Test LS GeoMAD"
 
-odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-geomad-cyear.db
-odc-stats run  --memory-limit=13GiB --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
+odc-stats save-tasks --config ./tests/test_configs/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-geomad-cyear.db
+odc-stats run  --memory-limit=13GiB --threads=1 --config ./tests/test_configs/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls8c_nbart_gm_cyear_3_x49y24_2015--P1Y_final*.tif
 
 echo "Test LS WO summary"
 
-odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-wofs-cyear.db
-odc-stats run  --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/wofs_summary/ga_ls_wo_fq_cyear_3.yaml --location file:///tmp --overwrite ls-wofs-cyear.db
+odc-stats save-tasks --config ./tests/test_configs/ga_ls_wo_fq_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-wofs-cyear.db
+odc-stats run  --threads=1 --config ./tests/test_configs/ga_ls_wo_fq_cyear_3.yaml --location file:///tmp --overwrite ls-wofs-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls_wo_fq_cyear_3_x49y24_2015--P1Y_fina*.tif
 
 echo "Test LS FC percentile"
 
-odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-fcp-cyear.db
-odc-stats run  --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/fc_percentile/ga_ls_fc_pc_cyear_3.yaml --location file:///tmp --overwrite ls-fcp-cyear.db
+odc-stats save-tasks --config ./tests/test_configs/ga_ls_fc_pc_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-fcp-cyear.db
+odc-stats run  --threads=1 --config ./tests/test_configs/ga_ls_fc_pc_cyear_3.yaml --location file:///tmp --overwrite ls-fcp-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls_fc_pc_cyear_3_x49y24_2015--P1Y_final*.tif
 
 echo "Test LS TC percentile"
-odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/tc_percentile/ga_ls_tc_pc_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-tcp-cyear.db
-odc-stats run  --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/tc_percentile/ga_ls_tc_pc_cyear_3.yaml --location file:///tmp --overwrite ls-tcp-cyear.db
+odc-stats save-tasks --config ./tests/test_configs/ga_ls_tc_pc_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-tcp-cyear.db
+odc-stats run  --threads=1 --config ./tests/test_configs/ga_ls_tc_pc_cyear_3.yaml --location file:///tmp --overwrite ls-tcp-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls_tc_pc_cyear_3_x49y24_2015--P1Y_final*.tif
 
 echo "Test Indexing"
 
-datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/5681c4bdced2fa5262554feac66e732d8bb824f9/products/baseline_satellite_data/geomedian-au/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
-datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/5681c4bdced2fa5262554feac66e732d8bb824f9/products/inland_water/wofs/ga_ls_wo_fq_cyear_3.odc-product.yaml
-datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/5681c4bdced2fa5262554feac66e732d8bb824f9/products/land_and_vegetation/fc/ga_ls_fc_pc_cyear_3.odc-product.yaml
-datacube product add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/5681c4bdced2fa5262554feac66e732d8bb824f9/products/inland_water/c3_tc/ga_ls_tc_pc_cyear_3.odc-product.yaml
+datacube product add ./tests/test_configs/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
+datacube product add ./tests/test_configs/ga_ls_wo_fq_cyear_3.odc-product.yaml
+datacube product add ./tests/test_configs/ga_ls_fc_pc_cyear_3.odc-product.yaml
+datacube product add ./tests/test_configs/ga_ls_tc_pc_cyear_3.odc-product.yaml
 
 fs-to-dc  --stac /tmp/x49/y24/
 

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -12,7 +12,7 @@ odc-stats --version
 echo "Test LS GeoMAD"
 
 odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-geomad-cyear.db
-odc-stats run  --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
+odc-stats run  --memory-limit=16GiB --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls8c_nbart_gm_cyear_3_x49y24_2015--P1Y_final*.tif
 

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -12,7 +12,7 @@ odc-stats --version
 echo "Test LS GeoMAD"
 
 odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-geomad-cyear.db
-odc-stats run  --memory-limit=15.6GiB --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
+odc-stats run  --memory-limit=13GiB --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls8c_nbart_gm_cyear_3_x49y24_2015--P1Y_final*.tif
 

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -12,7 +12,7 @@ odc-stats --version
 echo "Test LS GeoMAD"
 
 odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-geomad-cyear.db
-odc-stats run  --memory-limit=16GiB --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
+odc-stats run  --memory-limit=15.6GiB --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls8c_nbart_gm_cyear_3_x49y24_2015--P1Y_final*.tif
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,7 +10,7 @@ mock
 moto
 networkx
 numpy<2.0
-odc-algo>=1.0.1
+odc-algo>=1.1.0
 odc-cloud>=0.2.5
 odc-dscache>=1.9
 odc-geo>=0.5.0rc1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,6 +6,7 @@ deepdiff
 distributed>=2025.4
 eodatasets3>=1.9
 future_fstrings
+geomad
 mock
 moto
 networkx

--- a/tests/test_configs/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
+++ b/tests/test_configs/ga_ls8c_nbart_gm_cyear_3.odc-product.yaml
@@ -1,0 +1,62 @@
+name: ga_ls8c_nbart_gm_cyear_3
+description: Geoscience Australia Landsat Nadir BRDF Adjusted Reflectance Terrain, Landsat 8 Geomedian Calendar Year Collection 3
+license: CC-BY-4.0
+metadata_type: eo3
+
+metadata:
+  properties:
+    odc:file_format: GeoTIFF
+    odc:product_family: geomedian
+  product:
+    name: ga_ls8c_nbart_gm_cyear_3
+
+measurements:
+  - name: nbart_blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: sdev
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: edev
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: bcdev
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: count
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+load:
+  crs: 'EPSG:3577'
+  resolution: 
+    y: -30
+    x: 30
+  align:
+    y: 0
+    x: 0

--- a/tests/test_configs/ga_ls8c_nbart_gm_cyear_3.yaml
+++ b/tests/test_configs/ga_ls8c_nbart_gm_cyear_3.yaml
@@ -1,0 +1,93 @@
+plugin: gm-ls # this can help system find the relative plugin and plugin version
+plugin_config:
+  cloud_filters:
+    cloud:
+      - [dilation, 5]
+    shadow:
+      - [dilation, 10]
+  transform_code: EPSG:9688
+  area_of_interest: [-180, -90, 180, 90] # accommodate the fact of 326xx not intersecting 3577 in LS
+  bands: [nbart_blue, nbart_green, nbart_red]
+
+product:
+  name: ga_ls8c_nbart_gm_cyear_3
+  short_name: ga_ls8c_nbart_gm_cyear_3
+  version: 3.0.0
+  product_family: geomedian
+
+  # -- EO Dataset3 relative section --
+  naming_conventions_values: dea_c3
+  explorer_path: https://explorer.dea.ga.gov.au/
+  classifier: ard
+  maturity: final
+  collection_number: 3
+
+  inherit_skip_properties:
+    - eo:cloud_cover
+    - fmask:clear
+    - fmask:snow
+    - fmask:cloud
+    - fmask:water
+    - fmask:cloud_shadow
+    - eo:sun_elevation
+    - eo:sun_azimuth
+    - gqa:iterative_stddev_x
+    - gqa:iterative_stddev_y
+    - gqa:iterative_stddev_xy
+    - gqa:stddev_xy
+    - gqa:stddev_x
+    - gqa:stddev_y
+    - gqa:mean_xy
+    - gqa:mean_x
+    - gqa:mean_y
+    - gqa:abs_xy
+    - gqa:abs_x
+    - gqa:abs_y
+    - gqa:abs_iterative_mean_y
+    - gqa:abs_iterative_mean_x
+    - gqa:abs_iterative_mean_xy
+    - gqa:iterative_mean_xy
+    - gqa:iterative_mean_x
+    - gqa:iterative_mean_y
+    - gqa:cep90
+    - landsat:landsat_product_id
+    - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
+
+  preview_image_ows_style:
+    name: simple_rgb
+    title: Simple RGB
+    abstract: Simple true-colour image, using the red, green and blue bands
+    components:
+      red:
+        nbart_red: 1
+      green:
+        nbart_green: 1
+      blue:
+        nbart_blue: 1
+    scale_range:
+    - 0
+    - 3000
+
+aws_unsigned: True
+
+max_processing_time: 2400
+job_queue_max_lease: 300
+renew_safety_margin: 60
+future_poll_interval: 2
+s3_acl: public-read
+# Generic product attributes
+cog_opts:
+  zlevel: 9
+apply_eodatasets3: True
+output_location: >-
+  s3://dea-public-data-dev/derivative/ga_ls8c_nbart_gm_cyear_3/3-0-0
+
+# save-tasks options
+input_products: ga_ls8c_ard_3
+frequency: annual
+grid: au-30
+qga: 1

--- a/tests/test_configs/ga_ls8c_nbart_gm_cyear_3.yaml
+++ b/tests/test_configs/ga_ls8c_nbart_gm_cyear_3.yaml
@@ -7,7 +7,7 @@ plugin_config:
       - [dilation, 10]
   transform_code: EPSG:9688
   area_of_interest: [-180, -90, 180, 90] # accommodate the fact of 326xx not intersecting 3577 in LS
-  bands: [nbart_blue, nbart_green, nbart_red]
+  bands: [nbart_blue, nbart_green, nbart_red, nbart_contiguity]
 
 product:
   name: ga_ls8c_nbart_gm_cyear_3

--- a/tests/test_configs/ga_ls_fc_pc_cyear_3.odc-product.yaml
+++ b/tests/test_configs/ga_ls_fc_pc_cyear_3.odc-product.yaml
@@ -1,0 +1,76 @@
+name: ga_ls_fc_pc_cyear_3
+description: Geoscience Australia Landsat Fractional Cover Percentile Calendar Year Collection 3
+license: CC-BY-4.0
+metadata_type: eo3
+
+metadata: 
+  product:
+    name: ga_ls_fc_pc_cyear_3
+
+measurements:
+  - name: pv_pc_10
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: pv_pc_50
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: pv_pc_90
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: bs_pc_10
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: bs_pc_50
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: bs_pc_90
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: npv_pc_10
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: npv_pc_50
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: npv_pc_90
+    dtype: uint8
+    units: 'percent'
+    nodata: 255
+
+  - name: qa
+    dtype: uint8
+    units: '1'
+    nodata: 255
+    flags_definition:
+      qa:
+        bits: [0,1,2,3,4,5,6,7]
+        values:
+          0: insufficient observations wet
+          1: insufficient observations dry
+          2: sufficient observations
+        description: Quality Assurance
+
+load:
+  crs: 'EPSG:3577'
+  resolution: 
+    y: -30
+    x: 30
+  align:
+    y: 0
+    x: 0

--- a/tests/test_configs/ga_ls_fc_pc_cyear_3.yaml
+++ b/tests/test_configs/ga_ls_fc_pc_cyear_3.yaml
@@ -1,0 +1,95 @@
+plugin: fc-percentiles # this can help system find the relative plugin and plugin version
+plugin_config:
+  cloud_filters:
+    cloud:
+      - [dilation, 5]
+    cloud_shadow:
+      - [dilation, 10]
+  transform_code: EPSG:9688
+  area_of_interest: [-180, -90, 180, 90] # accommodate the fact of 326xx not intersecting 3577 in LS
+
+product:
+  name: ga_ls_fc_pc_cyear_3
+  short_name: ga_ls_fc_pc_cyear_3
+  version: 3.0.0
+  product_family: fc_percentile
+
+  # -- EO Dataset3 relative section --
+  naming_conventions_values: dea_c3
+  explorer_path: https://explorer.dea.ga.gov.au/
+  classifier: ard
+  maturity: final
+  collection_number: 3
+
+  inherit_skip_properties:
+    - eo:cloud_cover
+    - fmask:clear
+    - fmask:snow
+    - fmask:cloud
+    - fmask:water
+    - fmask:cloud_shadow
+    - eo:sun_elevation
+    - eo:sun_azimuth
+    - gqa:iterative_stddev_x
+    - gqa:iterative_stddev_y
+    - gqa:iterative_stddev_xy
+    - gqa:stddev_xy
+    - gqa:stddev_x
+    - gqa:stddev_y
+    - gqa:mean_xy
+    - gqa:mean_x
+    - gqa:mean_y
+    - gqa:abs_xy
+    - gqa:abs_x
+    - gqa:abs_y
+    - gqa:abs_iterative_mean_y
+    - gqa:abs_iterative_mean_x
+    - gqa:abs_iterative_mean_xy
+    - gqa:iterative_mean_xy
+    - gqa:iterative_mean_x
+    - gqa:iterative_mean_y
+    - gqa:cep90
+    - landsat:landsat_product_id
+    - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
+
+  preview_image_ows_style:
+    name: fc_rgb
+    title: Three-band fractional cover
+    abstract: Fractional cover medians - red is bare soil, green is green vegetation and
+      blue is non-green vegetation
+    components:
+      red:
+        bs_pc_50: 1
+      green:
+        pv_pc_50: 1
+      blue:
+        npv_pc_50: 1
+    scale_range:
+    - 0
+    - 100
+
+aws_unsigned: True
+
+max_processing_time: 1200
+job_queue_max_lease: 300
+renew_safety_margin: 60
+future_poll_interval: 2
+s3_acl: public-read
+# Generic product attributes
+cog_opts:
+  zlevel: 9
+apply_eodatasets3: True
+dataset_filters: >-
+  {"datetime": "1987-01--P17Y"}|{"datetime": "2004-01--P6Y", "eo:platform": "landsat-5"}|
+  {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}
+output_location: >-
+  s3://dea-public-data-dev/derivative/ga_ls_fc_pc_cyear_3/3-0-0
+
+# save-tasks options
+input_products: ga_ls_fc_3+ga_ls_wo_3
+frequency: annual
+grid: au-30

--- a/tests/test_configs/ga_ls_tc_pc_cyear_3.odc-product.yaml
+++ b/tests/test_configs/ga_ls_tc_pc_cyear_3.odc-product.yaml
@@ -1,0 +1,63 @@
+name: ga_ls_tc_pc_cyear_3
+description: Geoscience Australia Landsat Tasseled Cap Percentile Calendar Year Collection 3
+license: CC-BY-4.0
+metadata_type: eo3
+
+metadata: 
+  product:
+    name: ga_ls_tc_pc_cyear_3
+
+measurements:
+  - name: wet_pc_10
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: wet_pc_50
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: wet_pc_90
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: green_pc_10
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: green_pc_50
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: green_pc_90
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: bright_pc_10
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: bright_pc_50
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+  - name: bright_pc_90
+    dtype: int16
+    units: 'percent'
+    nodata: -9999
+
+load:
+  crs: 'EPSG:3577'
+  resolution: 
+    y: -30
+    x: 30
+  align:
+    y: 0
+    x: 0

--- a/tests/test_configs/ga_ls_tc_pc_cyear_3.yaml
+++ b/tests/test_configs/ga_ls_tc_pc_cyear_3.yaml
@@ -1,0 +1,96 @@
+plugin: tcw-percentiles # this can help system find the relative plugin and plugin version
+plugin_config:
+  cloud_filters:
+    cloud:
+      - [dilation, 5]
+    shadow:
+      - [dilation, 10]
+  transform_code: EPSG:9688
+  area_of_interest: [-180, -90, 180, 90] # accommodate the fact of 326xx not intersecting 3577 in LS
+
+product:
+  name: ga_ls_tc_pc_cyear_3
+  short_name: ga_ls_tc_pc_cyear_3
+  version: 1.0.0
+  product_family: tci
+  
+  # -- EO Dataset3 relative section --
+  naming_conventions_values: dea_c3
+  explorer_path: https://explorer.dea.ga.gov.au/
+  classifier: ard
+  maturity: final
+  collection_number: 3
+  
+  inherit_skip_properties:
+    - eo:cloud_cover
+    - fmask:clear
+    - fmask:snow
+    - fmask:cloud
+    - fmask:water
+    - fmask:cloud_shadow
+    - eo:sun_elevation
+    - eo:sun_azimuth
+    - gqa:iterative_stddev_x
+    - gqa:iterative_stddev_y
+    - gqa:iterative_stddev_xy
+    - gqa:stddev_xy
+    - gqa:stddev_x
+    - gqa:stddev_y
+    - gqa:mean_xy
+    - gqa:mean_x
+    - gqa:mean_y
+    - gqa:abs_xy
+    - gqa:abs_x
+    - gqa:abs_y
+    - gqa:abs_iterative_mean_y
+    - gqa:abs_iterative_mean_x
+    - gqa:abs_iterative_mean_xy
+    - gqa:iterative_mean_xy
+    - gqa:iterative_mean_x
+    - gqa:iterative_mean_y
+    - gqa:cep90
+    - landsat:landsat_product_id
+    - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
+
+  preview_image_ows_style:
+    name: tci_rgb
+    title: Three-band TCI 
+    abstract: TCI medians - red is brightness, green is greenness and
+      blue is wetness
+    components:
+      red:
+        bright_pc_50: 1
+      green:
+        green_pc_50: 1
+      blue:
+        wet_pc_50: 1
+    scale_range:
+    - -2000 
+    - 2000
+   
+aws_unsigned: True
+
+max_processing_time: 1200
+job_queue_max_lease: 300
+renew_safety_margin: 60
+future_poll_interval: 2
+s3_acl: public-read
+# Generic product attributes
+cog_opts:
+  zlevel: 9
+apply_eodatasets3: True
+dataset_filters: >-
+  {"datetime": "1987-01--P17Y"}|{"datetime": "2004-01--P6Y", "eo:platform": "landsat-5"}|
+  {"datetime": "2010-01--P3Y"}|{"datetime": "2013-01--P5M"}|{"eo:platform": "landsat-8"}
+output_location: >-
+  s3://dea-public-data-dev/derivative/ga_ls_tc_pc_cyear_3/1-0-0
+
+# save-tasks config
+input_products: ga_ls5t_ard_3-ga_ls7e_ard_3-ga_ls8c_ard_3
+frequency: annual
+grid: au-30
+gqa: 1

--- a/tests/test_configs/ga_ls_wo_fq_cyear_3.odc-product.yaml
+++ b/tests/test_configs/ga_ls_wo_fq_cyear_3.odc-product.yaml
@@ -1,0 +1,34 @@
+name: ga_ls_wo_fq_cyear_3 
+description: Geoscience Australia Landsat Water Observations Frequency Calendar Year Collection 3
+license: CC-BY-4.0
+metadata_type: eo3
+
+metadata:
+  properties:
+    odc:file_format: GeoTIFF
+    odc:product_family: wo
+  product: 
+    name: ga_ls_wo_fq_cyear_3 
+
+measurements:
+  - name: count_wet
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: count_clear
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: frequency
+    dtype: float32
+    nodata: .nan
+    units: '1'
+
+load:
+  crs: 'EPSG:3577'
+  resolution: 
+    y: -30
+    x: 30
+  align:
+    y: 0
+    x: 0

--- a/tests/test_configs/ga_ls_wo_fq_cyear_3.yaml
+++ b/tests/test_configs/ga_ls_wo_fq_cyear_3.yaml
@@ -1,0 +1,121 @@
+plugin: wofs-summary # this can help system find the relative plugin and plugin version
+plugin_config:
+  cloud_filters:
+    cloud:
+      - [dilation, 5]
+    cloud_shadow:
+      - [dilation, 10]
+  transform_code: EPSG:9688
+  area_of_interest: [-180, -90, 180, 90] # accommodate the fact of 326xx not intersecting 3577 in LS
+
+product:
+  name: ga_ls_wo_fq_cyear_3
+  short_name: ga_ls_wo_fq_cyear_3
+  version: 1.6.0
+  product_family: wo
+
+  # -- EO Dataset3 relative section --
+  naming_conventions_values: dea_c3
+  explorer_path: https://explorer.dea.ga.gov.au/
+  classifier: ard
+  maturity: final
+  collection_number: 3
+
+  inherit_skip_properties:
+    - eo:cloud_cover
+    - fmask:clear
+    - fmask:snow
+    - fmask:cloud
+    - fmask:water
+    - fmask:cloud_shadow
+    - eo:sun_elevation
+    - eo:sun_azimuth
+    - gqa:iterative_stddev_x
+    - gqa:iterative_stddev_y
+    - gqa:iterative_stddev_xy
+    - gqa:stddev_xy
+    - gqa:stddev_x
+    - gqa:stddev_y
+    - gqa:mean_xy
+    - gqa:mean_x
+    - gqa:mean_y
+    - gqa:abs_xy
+    - gqa:abs_x
+    - gqa:abs_y
+    - gqa:abs_iterative_mean_y
+    - gqa:abs_iterative_mean_x
+    - gqa:abs_iterative_mean_xy
+    - gqa:iterative_mean_xy
+    - gqa:iterative_mean_x
+    - gqa:iterative_mean_y
+    - gqa:cep90
+    - landsat:landsat_product_id
+    - landsat:landsat_scene_id
+    - landsat:collection_category
+    - landsat:collection_number
+    - landsat:wrs_path
+    - landsat:wrs_row
+
+  preview_image_ows_style:
+    # ref: https://github.com/GeoscienceAustralia/dea-config/blob/master/prod/services/wms/ows_refactored/inland_water/wofs/ows_wofs_annual_cfg.py#L7
+    name: annual_WOfS_frequency
+    title: Water Summary
+    abstract: WOfS annual summary showing the frequency of Wetness
+    index_function:
+      function: datacube_ows.band_utils.single_band
+      mapped_bands: 'True'
+      kwargs:
+        band: frequency
+    include_in_feature_info: 'False'
+    needed_bands:
+      - frequency
+    color_ramp:
+      - value: 0
+        color: '#000000'
+        alpha: 0
+      - value: 0.02
+        color: '#000000'
+        alpha: 0
+      - value: 0.05
+        color: '#8e0101'
+        alpha: 0.25
+      - value: 0.1
+        color: '#cf2200'
+        alpha: 0.75
+      - value: 0.2
+        color: '#e38400'
+      - value: 0.3
+        color: '#e3df00'
+      - value: 0.4
+        color: '#62e300'
+      - value: 0.5
+        color: '#00e32d'
+      - value: 0.6
+        color: '#00e3c8'
+      - value: 0.7
+        color: '#0097e3'
+      - value: 0.8
+        color: '#005fe3'
+      - value: 0.9
+        color: '#000fe3'
+      - value: 1
+        color: '#5700e3'
+
+aws_unsigned: True
+
+max_processing_time: 1200
+job_queue_max_lease: 300
+renew_safety_margin: 60
+future_poll_interval: 2
+s3_acl: public-read
+# Generic product attributes
+cog_opts:
+  zlevel: 9
+apply_eodatasets3: True
+output_location: >-
+  s3://dea-public-data-dev/derivative/ga_ls_wo_fq_cyear_3/1-6-0
+
+# save-tasks options
+input_products: ga_ls_wo_3
+frequency: annual
+grid: au-30

--- a/tests/test_gm_ls.py
+++ b/tests/test_gm_ls.py
@@ -82,7 +82,7 @@ def dataset():
 
 
 def test_native_transform(dataset):
-    _ = pytest.importorskip("hdstats")
+    _ = pytest.importorskip("geomad")
 
     dataset = dataset.copy()
     stats_gmls = StatsGMLS(nodata_classes=(0,))
@@ -104,7 +104,7 @@ def test_native_transform(dataset):
 
 
 def test_result_bands_to_match_inputs(dataset):
-    _ = pytest.importorskip("hdstats")
+    _ = pytest.importorskip("geomad")
     mask_filters = {
         "cloud": [("closing", 2), ("dilation", 1)],
         "shadow": [("closing", 0), ("dilation", 5)],
@@ -130,7 +130,7 @@ def test_result_bands_to_match_inputs(dataset):
 
 
 def test_result_aux_bands_to_match_inputs(dataset):
-    _ = pytest.importorskip("hdstats")
+    _ = pytest.importorskip("geomad")
     mask_filters = {
         "cloud": [("closing", 2), ("dilation", 1)],
         "shadow": [("closing", 0), ("dilation", 5)],
@@ -165,7 +165,7 @@ def test_result_aux_bands_to_match_inputs(dataset):
 
 
 def test_resampling(dataset):
-    _ = pytest.importorskip("hdstats")
+    _ = pytest.importorskip("geomad")
     mask_filters = {
         "cloud": [("closing", 2), ("dilation", 1)],
         "shadow": [("closing", 0), ("dilation", 5)],

--- a/tests/test_gm_ls_bitmask.py
+++ b/tests/test_gm_ls_bitmask.py
@@ -109,7 +109,7 @@ def test_fuser(dataset):
 
 
 def test_reduce(dataset):
-    _ = pytest.importorskip("hdstats")
+    _ = pytest.importorskip("geomad")
     gm = StatsGMLSBitmask(
         bands=["band_red"], offset=-0.2, scale=0.00975, output_scale=100
     )
@@ -140,7 +140,7 @@ def test_reduce(dataset):
 
 
 def test_reduce_with_filters(dataset):
-    _ = pytest.importorskip("hdstats")
+    _ = pytest.importorskip("geomad")
     mask_filters = [("closing", 2), ("dilation", 1)]
     gm = StatsGMLSBitmask(
         bands=["band_red"],
@@ -173,7 +173,7 @@ def test_reduce_with_filters(dataset):
 
 
 def test_aux_result_bands_to_match_inputs(dataset):
-    _ = pytest.importorskip("hdstats")
+    _ = pytest.importorskip("geomad")
     aux_names = dict(smad="SMAD", emad="EMAD", bcmad="BCMAD", count="COUNT")
     gm = StatsGMLSBitmask(
         bands=["band_red"],


### PR DESCRIPTION
See #207, this is that, but with lowered RAM usage allowed in GHA.

From my comment https://github.com/opendatacube/odc-stats/pull/207#issuecomment-3257350707
> That memory limit argument is used to tell dask how much memory it is allowed to use (and maybe to work out chuck sizes, I'm not sure).
> 
> I think GitHub actions runners have 16GB of RAM, so dask needs to use substantially less to not be killed.
> 
> The log messages from dask in the failed runs indicated it had decided to use about 14GB, so it must use a heuristic that assumes it can use most of the available ram, too much in this case.