### PR TITLE
Fix docker-compose.yml version warning [skip ci]

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   postgres:
     image: postgis/postgis:10-2.5


### PR DESCRIPTION
> "the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion"