### PR TITLE
docker: pull quietly

### DIFF
--- a/docker/test_statistician.sh
+++ b/docker/test_statistician.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-docker compose up -d
+docker compose up -d --quiet-pull
 sleep 5
 
 docker compose exec -T stats odc-stats --version


### PR DESCRIPTION
The progress meter produces a lot
of spam in the CI logs, so disable
it.