### PR TITLE
Upper bound dask/distributed

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -48,7 +48,7 @@ dependencies:
   - dask-image
   - deepdiff
   - defusedxml
-  - distributed>=2025.4
+  - distributed>=2025.4,<2025.9
   - docutils
   - fiona
   - Flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     click>=8.0.0
     dask
     datacube>=1.9.6
-    distributed>=2025.4
+    distributed>=2025.4,<2025.9
     numpy
     odc-cloud[ASYNC]>=0.2.5
     odc_algo>=1.0.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ datacube>=1.9.5
 datacube-ows>=1.9
 # for pytest-depends
 deepdiff
-distributed>=2025.4
+distributed>=2025.4,<2025.9
 eodatasets3>=1.9
 future_fstrings
 mock


### PR DESCRIPTION
Recently tests started failing with no apparent relevant change to the code; it appears related to the latest (2025.9) dask/distributed version. Restrict the version for now until we can properly resolve the compatibility issue.