### PR TITLE
Allow dask to spill to disk

### DIFF
--- a/docker/distributed.yaml
+++ b/docker/distributed.yaml
@@ -2,7 +2,7 @@
 distributed:
   worker:
     memory:
-      target: false
-      spill: false
+      target: 0.65
+      spill: 0.70
       pause: 0.95
       terminate: 0.97

--- a/tests/integration_test.sh
+++ b/tests/integration_test.sh
@@ -12,7 +12,7 @@ odc-stats --version
 echo "Test LS GeoMAD"
 
 odc-stats save-tasks --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --year=2015 --tiles 49:50,24:25 --overwrite ls-geomad-cyear.db
-odc-stats run  --threads=1 --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
+odc-stats run  --threads=1 --plugin-config "work_chunks: [100, 100]" --config https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/709daaee176c04e33de4cc9600462717cca5b34d/dev/services/odc-stats/geomedian/ga_ls8c_nbart_gm_cyear_3.yaml --location file:///tmp --overwrite ls-geomad-cyear.db
 
 ./tests/compare_data.sh /tmp/x49/y24/ ga_ls8c_nbart_gm_cyear_3_x49y24_2015--P1Y_final*.tif
 


### PR DESCRIPTION
The integration tests are failing due to high memory usage. 
This change 
* reduces the spatial size of the array to handle the year-long time depth.
* allows dask distributed to spill to disk when memory usage is high.
