### PR TITLE
setup.cfg: use datacube < 1.10.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     botocore
     click>=8.0.0
     dask
-    datacube>=1.9.6
+    datacube>=1.9.6,<1.10.0
     distributed>=2025.4,<2025.9
     numpy
     odc-cloud[ASYNC]>=0.2.5


### PR DESCRIPTION
This will keep the package working
even after the next API breaking
datacube version is released.