### PR TITLE
Rollback datacube to 1.9.5

### DIFF
--- a/.github/workflows/statistician-dive.yml
+++ b/.github/workflows/statistician-dive.yml
@@ -50,4 +50,4 @@ jobs:
         uses: wemake-services/docker-image-size-limit@2.0.0
         with:
           image: ${{ env.ORG }}/${{ env.IMAGE}}:_build
-          size: "3 GiB"
+          size: "3.5 GiB"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -3,7 +3,7 @@
 # For ML
 ai-edge-litert
 datacube-ows>=1.9
-datacube[performance,s3]>=1.9.5
+datacube[performance,s3]==1.9.5
 eodatasets3>1.9
 hdstats==0.1.8.post1
 numexpr>=2.11

--- a/odc/stats/_stac_fetch.py
+++ b/odc/stats/_stac_fetch.py
@@ -1,7 +1,7 @@
 import json
 
 from odc.aio import S3Fetcher, s3_find_glob
-from datacube.metadata import stac2ds
+from odc.stac.eo3 import stac2ds
 from pystac.item import Item
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,11 @@ install_requires =
     botocore
     click>=8.0.0
     dask
-    datacube>=1.9.6
+    datacube==1.9.5
     distributed>=2025.4,<2025.9
     numpy
     odc-cloud[ASYNC]>=0.2.5
-    odc_algo>=1.0.1
+    odc_algo>=1.0.1,<1.1 # Don't want geomad yet
     odc_dscache>=1.9
     odc_io
     odc-geo>=0.5.0rc1


### PR DESCRIPTION
Newer versions of datacube are causing issues with odc-stats running with a much larger memory footprint and blocking threads on masking operations.

Datacube 1.9.5 does not have these issues.

(1.9.6+1.9.7: has differences in handling dimensions required for chunking.)

Will roll forward when the issues have been resolved.