### PR TITLE
CI: use anchors for paths

### DIFF
--- a/.github/workflows/statistician-dive.yml
+++ b/.github/workflows/statistician-dive.yml
@@ -3,16 +3,13 @@ name: Statistician docker check
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - '.github/workflows/statistician-dive.yml'
       - 'docker/**'
       - '!docker/readme.md'
 
   push:
-    paths:
-      - '.github/workflows/statistician-dive.yml'
-      - 'docker/**'
-      - '!docker/readme.md'
+    paths: *paths
 
 env:
   ORG: odc

--- a/.github/workflows/statistician-image.yml
+++ b/.github/workflows/statistician-image.yml
@@ -6,15 +6,13 @@ env:
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - 'docker/**'
       - '!docker/readme.md'
   push:
     branches:
       - develop
-    paths:
-      - 'docker/**'
-      - '!docker/readme.md'
+    paths: *paths
   workflow_run:
     workflows: ["Publish to S3 and PyPI"]
     branches: [develop]


### PR DESCRIPTION
The path lists are meant to be identical,
so use the new yaml anchors to ensure that.