### PR TITLE
CICD: Don't publish to S3

### DIFF
--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -1,4 +1,4 @@
-name: Publish to S3 and PyPI
+name: Publish to PyPI
 
 on:
   workflow_run:
@@ -44,33 +44,3 @@ jobs:
         run: |
           ls wheels/clean/
           twine upload --non-interactive --skip-existing wheels/clean/*
-
-  publish-s3:
-    if: |
-        github.repository == 'opendatacube/odc-stats'
-        && github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: wheels_cache
-        with:
-          path: ./wheels
-          key: wheels-${{ github.sha }}
-
-      - name: Prepare for upload to S3
-        run: |
-          mkdir -p ./pips
-          ./scripts/mk-pip-tree.sh ./wheels/clean/ ./pips
-          find ./pips -type f
-
-      - name: Upload to S3
-        run: |
-          aws s3 ls "${S3_DST}"
-          aws s3 sync ./pips/ "${S3_DST}"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'ap-southeast-2'
-          AWS_REGION: 'ap-southeast-2'
-          S3_DST: 's3://datacube-core-deployment/'

--- a/.github/workflows/statistician-image.yml
+++ b/.github/workflows/statistician-image.yml
@@ -16,7 +16,7 @@ on:
       - 'docker/**'
       - '!docker/readme.md'
   workflow_run:
-    workflows: ["Publish to S3 and PyPI"]
+    workflows: ["Publish to PyPI"]
     branches: [develop]
     types:
       - completed


### PR DESCRIPTION
The DEA package repository is being decommissioned.
PyPI should be used instead.