### PR TITLE
Fix multi-crs concatination bug

### DIFF
--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - libgdal
   - gdal>=3.8
   - proj
-  - rasterio>=1.4.3
+  - rasterio>=1.4.4
   - gcc_linux-64
   - gxx_linux-64
   - binutils_linux-64

--- a/docker/env.yaml
+++ b/docker/env.yaml
@@ -6,7 +6,7 @@ dependencies:
   - libgdal
   - gdal>=3.8
   - proj
-  - rasterio>=1.4.4
+  - rasterio>=1.4.3
   - gcc_linux-64
   - gxx_linux-64
   - binutils_linux-64

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -2,7 +2,7 @@
 --extra-index-url https://packages.dea.ga.gov.au/
 # For ML
 ai-edge-litert
-datacube-ows>=1.9
+datacube-ows>=1.9,<1.9.8 # 1.9.8 drops py3.10
 datacube[performance,s3]==1.9.5
 eodatasets3>1.9
 hdstats==0.1.8.post1

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -14,7 +14,7 @@ odc-apps-dc-tools>=0.2.12
 odc-cloud>=0.2.5
 odc-dscache>=1.9
 odc-geo>=0.5.0rc1
-odc-stac>=0.4.0
+odc-stac==0.4.0 # 0.4.1 removes stac2ds, not moved to datacube until 1.9.6
 
 # odc-stac is in PyPI
 tl2cgen

--- a/odc/stats/_stac_fetch.py
+++ b/odc/stats/_stac_fetch.py
@@ -1,7 +1,11 @@
 import json
 
 from odc.aio import S3Fetcher, s3_find_glob
-from odc.stac.eo3 import stac2ds
+
+try:
+    from datacube.metadata import stac2ds
+except ImportError:
+    from odc.stac.eo3 import stac2ds
 from pystac.item import Item
 
 

--- a/odc/stats/io.py
+++ b/odc/stats/io.py
@@ -826,7 +826,9 @@ def load_with_native_transform(
     if len(_xx) == 1:
         xx = _xx[0]
     else:
-        xx = xr.concat(_xx, _xx[0].dims[0])  # type: ignore
+        sample_band = basis if basis is not None else bands[0]
+        concat_dim = _xx[0][sample_band].dims[0]
+        xx = xr.concat(_xx, dim=concat_dim)  # type: ignore
         if groupby != "idx":
             xx = xx.groupby(groupby).map(fuser)
     # TODO: probably want to replace spec MultiIndex with just `time` component

--- a/odc/stats/io.py
+++ b/odc/stats/io.py
@@ -828,7 +828,7 @@ def load_with_native_transform(
     else:
         sample_band = basis if basis is not None else bands[0]
         concat_dim = _xx[0][sample_band].dims[0]
-        xx = xr.concat(_xx, dim=concat_dim)  # type: ignore
+        xx = xr.concat(_xx, dim=concat_dim)  # type: ignore[assign]
         if groupby != "idx":
             xx = xx.groupby(groupby).map(fuser)
     # TODO: probably want to replace spec MultiIndex with just `time` component


### PR DESCRIPTION
Xarray has modified the way dims are exposed from `xr.Dataset`s, which has broken stats when trying to combine datasets of multiple CRSs.
To get the dims in order, we need to access the dims of a `xr.DataArray`.