### PR TITLE
Fix stale CRS metadata after reprojection

### DIFF
--- a/odc/stats/io.py
+++ b/odc/stats/io.py
@@ -33,7 +33,7 @@ from pyproj import aoi, transformer
 
 from odc.geo.geobox import GeoBox
 from odc.geo.geobox import pad as gbox_pad
-from odc.geo.xr import xr_reproject
+from odc.geo.xr import xr_reproject, assign_crs
 
 from ._grouper import group_by_nothing, solar_offset
 from odc.algo._masking import (
@@ -813,6 +813,9 @@ def load_with_native_transform(
             chunks=_chunks,
             **extra_args,
         )
+
+        # Ensure output advertises the destination CRS consistently
+        _yy = assign_crs(_yy, crs=geobox.crs)
 
         if isinstance(_yy, xr.DataArray) and vars_to_scale:
             _yy = _yy > 64

--- a/odc/stats/model.py
+++ b/odc/stats/model.py
@@ -528,8 +528,11 @@ class Task:
         )
         ProjectionExtension.add_to(item)
         proj_ext = ProjectionExtension.ext(item)
+
         proj_ext.apply(
-            epsg=geobox.crs.epsg, transform=geobox.transform, shape=list(geobox.shape)
+            epsg=geobox.crs.epsg, 
+            transform=list(geobox.transform),  # ensure transform is JSON serializable
+            shape=list(geobox.shape)
         )
 
         # Lineage last

--- a/odc/stats/model.py
+++ b/odc/stats/model.py
@@ -485,7 +485,7 @@ class Task:
 
         return dataset_assembler
 
-    def render_metadata(
+    def render_metadata(  # pylint: disable=too-many-locals
         self,
         ext: str = EXT_TIFF,
         processing_dt: datetime | None = None,
@@ -530,9 +530,9 @@ class Task:
         proj_ext = ProjectionExtension.ext(item)
 
         proj_ext.apply(
-            epsg=geobox.crs.epsg, 
+            epsg=geobox.crs.epsg,
             transform=list(geobox.transform),  # ensure transform is JSON serializable
-            shape=list(geobox.shape)
+            shape=list(geobox.shape),
         )
 
         # Lineage last

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -8,6 +8,7 @@ from odc.algo import geomedian_with_mads
 from ._registry import StatsPluginInterface, register
 from odc.algo import enum_to_bool, erase_bad
 from odc.algo import mask_cleanup
+from odc.geo.xr import assign_crs
 import logging
 
 _log = logging.getLogger(__name__)
@@ -122,6 +123,21 @@ class StatsGM(StatsPluginInterface):
 
         gm = geomedian_with_mads(xx, **cfg)
         gm = gm.rename(self._renames)
+
+        # geomedian_with_mads drops spatial_ref; re-attach from input
+        crs = getattr(xx.odc, "crs", None)  # type: ignore[attr-defined]
+        if crs is not None:
+            gm = gm.copy()
+            
+            # Remove stale CRS metadata
+            gm.attrs.pop("crs", None)
+            gm.attrs.pop("grid_mapping", None)
+            for v in gm.data_vars:
+                gm[v].attrs.pop("crs", None)
+                gm[v].attrs.pop("grid_mapping", None)
+            
+            gm = gm.drop_vars(["spatial_ref", "crs"], errors="ignore")
+            gm = assign_crs(gm, crs=crs)
 
         return gm
 

--- a/odc/stats/plugins/gm.py
+++ b/odc/stats/plugins/gm.py
@@ -128,14 +128,14 @@ class StatsGM(StatsPluginInterface):
         crs = getattr(xx.odc, "crs", None)  # type: ignore[attr-defined]
         if crs is not None:
             gm = gm.copy()
-            
+
             # Remove stale CRS metadata
             gm.attrs.pop("crs", None)
             gm.attrs.pop("grid_mapping", None)
             for v in gm.data_vars:
                 gm[v].attrs.pop("crs", None)
                 gm[v].attrs.pop("grid_mapping", None)
-            
+
             gm = gm.drop_vars(["spatial_ref", "crs"], errors="ignore")
             gm = assign_crs(gm, crs=crs)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ install_requires =
     botocore
     click>=8.0.0
     dask
-    datacube==1.9.5
+    datacube>=1.9.5
+    odc-stac==0.4.0
     distributed>=2025.4,<2025.9
     numpy
     odc-cloud[ASYNC]>=0.2.5


### PR DESCRIPTION
## Problem

While processing data with odc-stats, I noticed the pipeline correctly reprojects data to the target grid, but the CRS metadata revert to the native CRS downstream. This causes:

- Inconsistent STAC vs GeoTIFF metadata (STAC shows target CRS, GeoTIFF tags show native CRS)
- Downstream tools reading incorrect CRS from file headers

## Root Cause Analysis

> [!IMPORTANT]
> **Custom instrumentation for diagnosis**
> To diagnose this issue, I added **custom CRS/grid logging** at key pipeline points to track where CRS metadata diverges from actual coordinates. All log lines below (marked WARNING - CRS ...) are from this custom instrumentatio. They're not standard odc-stats output. 
>
> The logs track:
> - CRS before/after reprojection  
> - Coordinate ranges (to verify grid transformation)
> - CRS metadata at reducer entry/exit

### Initial observation
<img width="2280" height="1127" alt="bugs_evidence" src="https://github.com/user-attachments/assets/9b18e2b3-8234-4eeb-903a-d2d372d23cd4" />

The logs reveal the inconsistency:

- `pre_reproject` shows native UTM coordinates: x=[315375..373265], y=[43435..-95] -> EPSG:32649
- `post_reproject` shows **coordinates transformed** to the target grid: x=[1.055e+07..1.06e+07], y=[49995..5] -> EPSG:6933 range
- BUT the CRS metadata still reports crs=EPSG:32649

> [!Note]
> **Identified Issue:** The reprojection warps the grid correctly, but the CRS metadata remains stale and affects the downstream.


### Fix 1: Assign CRS after reprojection

- After `xr_reproject`, I explicitly assign the CRS to match the destination grid

- This ensures the post-reproject dataset is internally consistent: both coordinates AND CRS metadata reflect the target grid.

<img width="2282" height="1110" alt="fix_01_bugs_02_evidence_2" src="https://github.com/user-attachments/assets/032cec10-ae48-46d1-94ee-00358959fa66" />

- After applying Fix 1:

     - `post_reproject` now correctly shows `crs=EPSG:6933` 
     - Coordinates and CRS metadata are properly aligned
     - **However**, there's still an issue downstream.

> [!Note]
> **Issue:** Downstream in the gm plugin - reducer(), the dataset enters with the grid CRS (EPSG:6933) but exits with the native CRS again (EPSG:32649).

### Fix 2: Prevent CRS regression in gm reducer

**The fix:**
1. Capture the authoritative CRS from `.odc.crs`
2. Remove all stale CRS/grid-mapping metadata
3. Cleanly re-attach the CRS

**Evidence**

<img width="2287" height="863" alt="bug_fix_evidence" src="https://github.com/user-attachments/assets/47dc4b5d-3327-4251-b837-ebc5506af282" />


### With both fixes applied:

- [x] Post-reproject CRS is correct 
- [x] Coordinates match the target grid
- [x] Reducer maintains CRS throughout
- [x] No CRS regression
- [x] STAC and GeoTIFF metadata remain consistent


### Other smaller changes

- **Ensure `proj:transform` is JSON serialisable**  
  changed: `transform=geobox.transform` -> `transform=list(geobox.transform)`

I hit a case where `geobox.transform` was still an `Affine` object, which is not JSON serialisable and can break STAC/item serialisation. Converting to `list(...)` ensures we always write a JSON-safe transform.

- **Relax datacube pin and lock odc-stac version**

Changed: `datacube==1.9.5` to `datacube>=1.9.5` and pinned `odc-stac==0.4.0`.

`_stac_fetch.py` imports `stac2ds` from odc-stac. In newer datacube versions (≥1.9.6), stac2ds also exists in datacube.metadata, but as long as we pin odc-stac==0.4.0, the import remains unambiguous and works correctly. 

Tested successfully with datacube 1.9.10.