### PR TITLE
fix: utcnow deprecated in python 3.12

### DIFF
--- a/odc/stats/model.py
+++ b/odc/stats/model.py
@@ -2,7 +2,7 @@ import math
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, UTC
 from typing import Any
 from collections.abc import Sequence
 from uuid import UUID, uuid5
@@ -236,7 +236,7 @@ class WorkTokenInterface(ABC):
         """
         Implementations should use this method internally
         """
-        return datetime.utcnow()
+        return datetime.now(UTC)
 
     @property
     @abstractmethod
@@ -458,7 +458,7 @@ class Task:
         warnings.filterwarnings("default")
 
         if processing_dt is None:
-            processing_dt = datetime.utcnow()
+            processing_dt = datetime.now(tz=UTC)
         dataset_assembler.processed = processing_dt
 
         dataset_assembler.maturity = self.product.maturity
@@ -495,7 +495,7 @@ class Task:
         Put together STAC metadata document for the output of this task.
         """
         if processing_dt is None:
-            processing_dt = datetime.utcnow()
+            processing_dt = datetime.now(UTC)
 
         product = self.product
         geobox = self.geobox

--- a/odc/stats/model.py
+++ b/odc/stats/model.py
@@ -2,7 +2,7 @@ import math
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone, UTC
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from collections.abc import Sequence
 from uuid import UUID, uuid5
@@ -236,7 +236,7 @@ class WorkTokenInterface(ABC):
         """
         Implementations should use this method internally
         """
-        return datetime.now(UTC)
+        return datetime.now(timezone.UTC)
 
     @property
     @abstractmethod
@@ -458,7 +458,7 @@ class Task:
         warnings.filterwarnings("default")
 
         if processing_dt is None:
-            processing_dt = datetime.now(tz=UTC)
+            processing_dt = datetime.now(tz=timezone.UTC)
         dataset_assembler.processed = processing_dt
 
         dataset_assembler.maturity = self.product.maturity
@@ -495,7 +495,7 @@ class Task:
         Put together STAC metadata document for the output of this task.
         """
         if processing_dt is None:
-            processing_dt = datetime.now(UTC)
+            processing_dt = datetime.now(timezone.UTC)
 
         product = self.product
         geobox = self.geobox

--- a/odc/stats/model.py
+++ b/odc/stats/model.py
@@ -236,7 +236,7 @@ class WorkTokenInterface(ABC):
         """
         Implementations should use this method internally
         """
-        return datetime.now(timezone.UTC)
+        return datetime.now(timezone.utc)
 
     @property
     @abstractmethod
@@ -458,7 +458,7 @@ class Task:
         warnings.filterwarnings("default")
 
         if processing_dt is None:
-            processing_dt = datetime.now(tz=timezone.UTC)
+            processing_dt = datetime.now(tz=timezone.utc)
         dataset_assembler.processed = processing_dt
 
         dataset_assembler.maturity = self.product.maturity
@@ -495,7 +495,7 @@ class Task:
         Put together STAC metadata document for the output of this task.
         """
         if processing_dt is None:
-            processing_dt = datetime.now(timezone.UTC)
+            processing_dt = datetime.now(timezone.utc)
 
         product = self.product
         geobox = self.geobox

--- a/odc/stats/proc.py
+++ b/odc/stats/proc.py
@@ -195,7 +195,7 @@ class TaskRunner:
         Records the timestamp at which a hearbeat was detected
 
         """
-        t_now = datetime.now(timezone.UTC)
+        t_now = datetime.now(timezone.utc)
         with open(f"{hearbeat_filepath}", "w", encoding="utf-8") as file_obj:
             file_obj.write(t_now.strftime("%Y-%m-%d %H:%M:%S"))
 

--- a/odc/stats/proc.py
+++ b/odc/stats/proc.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 from collections.abc import Iterable, Iterator
 from dask.distributed import Client, WorkerPlugin
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 import xarray as xr
 import math
 import psutil
@@ -195,7 +195,7 @@ class TaskRunner:
         Records the timestamp at which a hearbeat was detected
 
         """
-        t_now = datetime.utcnow()
+        t_now = datetime.now(UTC)
         with open(f"{hearbeat_filepath}", "w", encoding="utf-8") as file_obj:
             file_obj.write(t_now.strftime("%Y-%m-%d %H:%M:%S"))
 

--- a/odc/stats/proc.py
+++ b/odc/stats/proc.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 from collections.abc import Iterable, Iterator
 from dask.distributed import Client, WorkerPlugin
-from datetime import datetime, timezone, UTC
+from datetime import datetime, timezone
 import xarray as xr
 import math
 import psutil
@@ -195,7 +195,7 @@ class TaskRunner:
         Records the timestamp at which a hearbeat was detected
 
         """
-        t_now = datetime.now(UTC)
+        t_now = datetime.now(timezone.UTC)
         with open(f"{hearbeat_filepath}", "w", encoding="utf-8") as file_obj:
             file_obj.write(t_now.strftime("%Y-%m-%d %H:%M:%S"))
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 Utilities for unit tests
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import time
 from uuid import UUID
 import xarray as xr
@@ -104,7 +104,7 @@ def mk_dask_xx(
     if chunks is None:
         chunks = {"x": -1, "y": -1}
     if timestamps is None:
-        timestamps = [datetime.utcnow()]
+        timestamps = [datetime.now(UTC)]
 
     dtype = np.dtype(dtype)
     _chunks = (chunks.get("time", 1), chunks.get("y", -1), chunks.get("x", -1))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 Utilities for unit tests
 """
 
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
 import time
 from uuid import UUID
 import xarray as xr
@@ -104,7 +104,7 @@ def mk_dask_xx(
     if chunks is None:
         chunks = {"x": -1, "y": -1}
     if timestamps is None:
-        timestamps = [datetime.now(UTC)]
+        timestamps = [datetime.now(timezone.UTC)]
 
     dtype = np.dtype(dtype)
     _chunks = (chunks.get("time", 1), chunks.get("y", -1), chunks.get("x", -1))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 Utilities for unit tests
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import time
 from uuid import UUID
 import xarray as xr

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -104,7 +104,7 @@ def mk_dask_xx(
     if chunks is None:
         chunks = {"x": -1, "y": -1}
     if timestamps is None:
-        timestamps = [datetime.now(timezone.UTC)]
+        timestamps = [datetime.now(timezone.utc)]
 
     dtype = np.dtype(dtype)
     _chunks = (chunks.get("time", 1), chunks.get("y", -1), chunks.get("x", -1))

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -41,7 +41,7 @@ def test_publish_sqs(test_db_filter_path, test_geom_path):
 def test_sqs_work_token(sqs_message):
     tk = SQSWorkToken(sqs_message, 60)
 
-    _now = datetime.now(timezone.UTC)
+    _now = datetime.now(timezone.utc)
     assert tk.active_seconds < 2
     assert tk.start_time < _now
     assert tk.deadline > _now
@@ -66,7 +66,7 @@ def test_sqs_work_token(sqs_message):
     tk = SQSWorkToken(sqs_message, 60)
 
     assert tk.active_seconds < 2
-    assert tk.deadline > datetime.now(timezone.UTC)
+    assert tk.deadline > datetime.now(timezone.utc)
     tk.cancel()
     assert tk._msg is None
     # should be no-op
@@ -86,7 +86,7 @@ def test_rdr_sqs(sqs_queue_by_name, test_db_path):
     for task in rdr.stream_from_sqs(
         sqs_queue_by_name, visibility_timeout=120, max_wait=0
     ):
-        _now = datetime.now(timezone.UTC)
+        _now = datetime.now(timezone.utc)
         assert task.source is not None
         assert task.source.active_seconds < 2
         assert task.source.deadline > _now

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta
 
 import boto3
 import moto
@@ -42,8 +42,8 @@ def test_sqs_work_token(sqs_message):
     tk = SQSWorkToken(sqs_message, 60)
 
     assert tk.active_seconds < 2
-    assert tk.start_time < datetime.now(UTC)
-    assert tk.deadline > datetime.now(UTC)
+    assert tk.start_time < datetime.now(timezone.UTC)
+    assert tk.deadline > datetime.now(timezone.UTC)
 
     deadline0 = tk.deadline
     assert tk.extend_if_needed(1000, 1)
@@ -65,7 +65,7 @@ def test_sqs_work_token(sqs_message):
     tk = SQSWorkToken(sqs_message, 60)
 
     assert tk.active_seconds < 2
-    assert tk.deadline > datetime.now(UTC)
+    assert tk.deadline > datetime.now(timezone.UTC)
     tk.cancel()
     assert tk._msg is None
     # should be no-op
@@ -85,7 +85,7 @@ def test_rdr_sqs(sqs_queue_by_name, test_db_path):
     for task in rdr.stream_from_sqs(
         sqs_queue_by_name, visibility_timeout=120, max_wait=0
     ):
-        _now = datetime.now(UTC)
+        _now = datetime.now(timezone.UTC)
         assert task.source is not None
         assert task.source.active_seconds < 2
         assert task.source.deadline > _now

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import boto3
 import moto
@@ -41,9 +41,10 @@ def test_publish_sqs(test_db_filter_path, test_geom_path):
 def test_sqs_work_token(sqs_message):
     tk = SQSWorkToken(sqs_message, 60)
 
+    _now = datetime.now(timezone.UTC)
     assert tk.active_seconds < 2
-    assert tk.start_time < datetime.now(timezone.UTC)
-    assert tk.deadline > datetime.now(timezone.UTC)
+    assert tk.start_time < _now
+    assert tk.deadline > _now
 
     deadline0 = tk.deadline
     assert tk.extend_if_needed(1000, 1)

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import boto3
 import moto
@@ -42,8 +42,8 @@ def test_sqs_work_token(sqs_message):
     tk = SQSWorkToken(sqs_message, 60)
 
     assert tk.active_seconds < 2
-    assert tk.start_time < datetime.utcnow()
-    assert tk.deadline > datetime.utcnow()
+    assert tk.start_time < datetime.now(UTC)
+    assert tk.deadline > datetime.now(UTC)
 
     deadline0 = tk.deadline
     assert tk.extend_if_needed(1000, 1)
@@ -65,7 +65,7 @@ def test_sqs_work_token(sqs_message):
     tk = SQSWorkToken(sqs_message, 60)
 
     assert tk.active_seconds < 2
-    assert tk.deadline > datetime.utcnow()
+    assert tk.deadline > datetime.now(UTC)
     tk.cancel()
     assert tk._msg is None
     # should be no-op
@@ -85,7 +85,7 @@ def test_rdr_sqs(sqs_queue_by_name, test_db_path):
     for task in rdr.stream_from_sqs(
         sqs_queue_by_name, visibility_timeout=120, max_wait=0
     ):
-        _now = datetime.utcnow()
+        _now = datetime.now(UTC)
         assert task.source is not None
         assert task.source.active_seconds < 2
         assert task.source.deadline > _now


### PR DESCRIPTION
To resolve:
```DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).```